### PR TITLE
🌟 Feature#2 : PostgreSQL DB 연동 및 build.gradle에 PostgreSQL Driver 설정 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 HELP.md
 .gradle
+.github
 build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
@@ -35,3 +36,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Properties ###
+src/main/resources/application-dev.properties

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,9 @@ repositories {
 }
 
 dependencies {
-//	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// PostgreSQL JDBC Driver
+	implementation 'org.postgresql:postgresql'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+# ?? ??
 spring.application.name=shootpointer
+spring.profiles.active=dev
+
+# JPA ?? ??
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #2  

---

## ✅ 작업 사항
1. IntelliJ IDEA에 PostgreSQL DB 연동 및 shootpointer DB 생성
2. build.gradle에 `implementation 'org.postgresql:postgresql'` Driver 설정

---

## ⌨ 기타
-> 추가해야할 작업 :  PostgreSQL, MongoDB, Redis를 Docker Compose로 구성하기