### PR TITLE
🛠️ Refactor : Member Id Type  Long -> UUID 변환

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/backnumber/service/BackNumberServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/backnumber/service/BackNumberServiceImpl.java
@@ -46,11 +46,11 @@ public class BackNumberServiceImpl implements BackNumberService{
     @Transactional
     @CustomLog
     public BackNumberResponse create(BackNumberRequest request) {
-        UUID userId=jwtUtil.getUserId();
+        UUID memberId = jwtUtil.getMemberId();
         //TODO: 임의로 멤버 id값 지정 및 예외처리 수정
-        Long memberId=1L;
-        Member member=memberRepository.findByMemberId(memberId)
-                .orElseThrow();
+
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         //1. 요청 등 번호가 있는지 확인
         BackNumber requestBackNumber=BackNumber.of(request.getBackNumber());
@@ -69,7 +69,7 @@ public class BackNumberServiceImpl implements BackNumberService{
 
         //3. OpenCV 사진 전송
         try {
-            openCVClient.sendBackNumberInformation(userId, requestBackNumber.getNumber(), request.getImage());
+            openCVClient.sendBackNumberInformation(memberId, requestBackNumber.getNumber(), request.getImage());
         }catch (Exception e){
             throw new CustomException(ErrorCode.FAILED_SEND_IMAGE_TO_OPENCV);
         }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -29,7 +29,7 @@ public class HighlightEntity extends BaseEntity {
     private Boolean isSelected=false;
 
     @ManyToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "BINARY(16)")
+    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "uuid")
     private Member member;
 
     @ManyToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -29,7 +29,7 @@ public class HighlightEntity extends BaseEntity {
     private Boolean isSelected=false;
 
     @ManyToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "member_id",nullable = false)
+    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "BINARY(16)")
     private Member member;
 
     @ManyToOne(cascade = CascadeType.ALL)

--- a/src/main/java/com/midas/shootpointer/domain/member/dto/KakaoDTO.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/dto/KakaoDTO.java
@@ -7,7 +7,6 @@ import lombok.Data;
 @Data
 public class KakaoDTO {
 
-    private long id;
     private String email;
     private String nickname;
     private String accessToken;

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Data
@@ -21,9 +22,9 @@ import java.util.List;
 public class Member extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "member_id")
-    private Long memberId;
+    @GeneratedValue
+    @Column(name = "member_id", columnDefinition = "BINARY(16)")
+    private UUID memberId;
 
     @Column(name = "member_name")
     @Convert(converter = EncryptConverter.class)

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ import java.util.UUID;
 public class Member extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue
+    @UuidGenerator
     @Column(name = "member_id", columnDefinition = "uuid")
     private UUID memberId;
 

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -23,7 +23,7 @@ public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue
-    @Column(name = "member_id", columnDefinition = "BINARY(16)")
+    @Column(name = "member_id", columnDefinition = "uuid")
     private UUID memberId;
 
     @Column(name = "member_name")

--- a/src/main/java/com/midas/shootpointer/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/repository/MemberRepository.java
@@ -5,10 +5,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.UUID;
 
 @Repository
-public interface MemberRepository extends JpaRepository<Member, Long> {
+public interface MemberRepository extends JpaRepository<Member, UUID> {
 
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByMemberId(Long memberId);
+    Optional<Member> findByMemberId(UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/service/KakaoService.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/service/KakaoService.java
@@ -167,7 +167,6 @@ public class KakaoService {
             JSONObject account = (JSONObject) jsonObj.get("kakao_account");
             JSONObject profile = (JSONObject) account.get("profile");
 
-            long id = (long) jsonObj.get("id");
             String email = String.valueOf(account.get("email"));
             String nickname = String.valueOf(profile.get("nickname"));
 
@@ -176,7 +175,6 @@ public class KakaoService {
             }
 
             return KakaoDTO.builder()
-                    .id(id)
                     .email(email)
                     .nickname(nickname)
                     .build();

--- a/src/main/java/com/midas/shootpointer/domain/memberbacknumber/entity/MemberBackNumberEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/memberbacknumber/entity/MemberBackNumberEntity.java
@@ -19,7 +19,7 @@ public class MemberBackNumberEntity {
     private Long memberBackNumberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "BINARY(16)")
+    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "uuid")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/midas/shootpointer/domain/memberbacknumber/entity/MemberBackNumberEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/memberbacknumber/entity/MemberBackNumberEntity.java
@@ -19,7 +19,7 @@ public class MemberBackNumberEntity {
     private Long memberBackNumberId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id",nullable = false)
+    @JoinColumn(name = "member_id",nullable = false, columnDefinition = "BINARY(16)")
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
      * highlight:                  20
      * member:                     30
      * global:                     40
+     * backnumber :                50
 
      * <p>
      * - Package
@@ -49,15 +50,20 @@ public enum ErrorCode {
     JWT_PARSE_FAIL(40404, HttpStatus.INTERNAL_SERVER_ERROR, "JWT 파싱 실패"),
     JWT_DECODE_FAIL(40405, HttpStatus.INTERNAL_SERVER_ERROR, "JWT 디코딩 실패"),
     SPRING_CONTEXT_BEAN_NOT_FOUND(40406, HttpStatus.INTERNAL_SERVER_ERROR, "스프링 빈을 찾을 수 없음"),
+    JWT_MEMBER_ID_INVALID(40407, HttpStatus.INTERNAL_SERVER_ERROR, "JWT에서 memberId(UUID) 추출 실패"),
+    JWT_REQUEST_NOT_FOUND(40408, HttpStatus.NOT_FOUND, "요청 Context를 찾을 수 없음"),
+    JWT_HEADER_NOT_FOUND(40409, HttpStatus.NOT_FOUND, "Authorization 헤더가 없음"),
 
     INTERNAL_ERROR_OF_PYTHON_SERVER(40501,HttpStatus.BAD_REQUEST,"파이썬 서버 내부 오류입니다."),
 
     //5XX
     FAILED_SEND_IMAGE_TO_OPENCV(20501,HttpStatus.GATEWAY_TIMEOUT,"OpenCV 등 번호 이미지 전송 실패"),
-    FAILED_POST_API_RETRY_TO_OPENCV(20502,HttpStatus.REQUEST_TIMEOUT,"OpenCV 파일 전송 횟수가 초과했습니다.")
-    ;
+    FAILED_POST_API_RETRY_TO_OPENCV(20502, HttpStatus.REQUEST_TIMEOUT, "OpenCV 파일 전송 횟수가 초과했습니다."),
 
 
+    // 502(backnumber - service) part
+    //* TODO : 현재 멤버 관련 로직이 Kakao 밖에 없어서 Member 도메인에 예외처리가 처음 생긴게 BackNumber 도메인임. << 이 부분은 추후에 Member 도메인에 로직 생기면 바꿀게요~
+    MEMBER_NOT_FOUND(50201, HttpStatus.NOT_FOUND, "Member를 찾을 수 없음");
 
 
     private final Integer code;

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,6 +38,8 @@ spring:
         format_sql: ${SPRING_JPA_PROPERTIES_HIBERNATE_FORMAT_SQL:true}
         use_sql_comments: true
         show-sql: true
+        type:
+          preferred_uuid_jdbc_type: uuid
 
   # MongoDB 설정
 

--- a/src/test/java/com/midas/shootpointer/domain/backnumber/service/BackNumberServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/backnumber/service/BackNumberServiceImplTest.java
@@ -68,9 +68,9 @@ class BackNumberServiceImplTest {
         BackNumberEntity mockBackNumberEntity = mockBackNumberEntity(mockBackNumber);
         BackNumberResponse expectedResponse = BackNumberResponse.of(100);
 
-        when(jwtUtil.getUserId())
+        when(jwtUtil.getMemberId())
                 .thenReturn(mockUserId);
-        when(memberRepository.findByMemberId(1L))
+        when(memberRepository.findByMemberId(mockUserId))
                 .thenReturn(Optional.of(mockMember));
         when(backNumberRepository.findByBackNumber(mockBackNumber))
                 .thenReturn(Optional.of(mockBackNumberEntity));
@@ -103,9 +103,9 @@ class BackNumberServiceImplTest {
         BackNumberEntity mockBackNumberEntity = mockBackNumberEntity(mockBackNumber);
         BackNumberResponse expectedResponse = BackNumberResponse.of(100);
 
-        when(jwtUtil.getUserId())
+        when(jwtUtil.getMemberId())
                 .thenReturn(mockUserId);
-        when(memberRepository.findByMemberId(1L))
+        when(memberRepository.findByMemberId(mockUserId))
                 .thenReturn(Optional.of(mockMember));
         //등 번호가 존재하지 않음
         when(backNumberRepository.findByBackNumber(mockBackNumber))
@@ -142,9 +142,9 @@ class BackNumberServiceImplTest {
         BackNumber mockBackNumber = BackNumber.of(request.getBackNumber());
         BackNumberEntity mockBackNumberEntity = mockBackNumberEntity(mockBackNumber);
 
-        when(jwtUtil.getUserId())
+        when(jwtUtil.getMemberId())
                 .thenReturn(mockUserId);
-        when(memberRepository.findByMemberId(1L))
+        when(memberRepository.findByMemberId(mockUserId))
                 .thenReturn(Optional.of(mockMember));
         when(backNumberRepository.findByBackNumber(mockBackNumber))
                 .thenReturn(Optional.of(mockBackNumberEntity));
@@ -166,7 +166,7 @@ class BackNumberServiceImplTest {
      */
     private Member mockMember() {
         return Member.builder()
-                .memberId(1L)
+                .memberId(UUID.randomUUID())
                 .email("test@naver.com")
                 .username("test")
                 .build();


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #37

---

## ❓왜 식별키 변환 작업을 했는가
---
🚨 기존 memberId는 직관적이고, 개발자가 편하고 메모리 관점에서 효율적인 Long 타입을 사용했습니다.

💡새로 작업한 UUID 타입의 memberId는 Long 타입보다 직관적이지 않고 메모리 관점에서도 성능이 다소 떨어지는 단점이 있지만, 세션 하이재킹과 같은 토큰 탈취가 이루어 졌을 때 보안 상 Long 타입의 식별키보다 월등히 뛰어남을 인지했습니다. 요즘 보안이 민감한 시대이기 때문에 보안에 초점을 둔 방식을 채택했습니다.

---

## ✅ 작업 사항
1. 기존 `Member Entity` 의 식별키를 UUID 타입으로 변경
> 주의할 점 : `columnDefinition = "uuid"` 설정을 하거나, yml에 JPA 설정 꼭 하기
2. JwtUtil 클래스 내부에 `getMemberId()` 메서드 구현
3. 부가적인 Error Code 작성 및 Test Code 수정
4. 실제 UUID 값이 잘 들어가는지 확인 완료

---

## ⌨ 기타

@tkv00 리뷰어 분께서 몇 가지만 확인해 주시면 합니다!

1. **DB Table Drop 후 재빌드 반드시 확인하기**
![image](https://github.com/user-attachments/assets/768ad5cc-b7aa-41f1-9a3b-ba14ed083b42)

이런 식으로 uuid 타입이 들어와야 합니다.

2. **간단한 테스트 완료 후 member_id 컬럼에 값이 잘 들어가는지 확인하기**
![image](https://github.com/user-attachments/assets/a0ff8694-1e3d-4f2b-99ea-dc6ef205b1ea)

저는 간단히 카카오 로그인 후 DB에 저장되는 값을 확인했는데, 추후 다른 API에서 값이 잘 들어가는지 확인 바랍니다.

3. **application-dev.yml 파일 확인하기**
![image](https://github.com/user-attachments/assets/bbad991b-9955-42b0-902b-ab4ecb70f7b7)

작업 사항에서 언급했던 것처럼 JPA 설정에 `type:preferred_uuid_jdbc_type: uuid` 부분을 꼭 확인 바랍니다.


_추가적으로 Error Code에 현재 MEMBER_NOT_FOUND 를 BackNumber 도메인에 적용했는데, 추후에 Member 관련 로직을 구현할 때 Error Code를 옮길 예정입니다._