### PR TITLE
🌟Feature : 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
@@ -34,6 +34,10 @@ public class MemberManager {
         return member.getMemberId();
     }
     
+    public Member findMemberById(UUID memberId) {
+        return memberHelper.findMemberById(memberId);
+    }
+    
     private Member findOrCreateMember(KakaoDTO kakaoDTO) {
         try {
             return memberHelper.findMemberByEmail(kakaoDTO.getEmail());

--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
@@ -8,6 +8,6 @@ public interface MemberCommandService {
     
     KakaoDTO processKakaoLogin(HttpServletRequest request);
 
-    UUID deleteMember(UUID memberId);
+    UUID deleteMember(HttpServletRequest request);
     
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
@@ -1,7 +1,6 @@
 package com.midas.shootpointer.domain.member.business.command;
 
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
-import com.midas.shootpointer.domain.member.entity.Member;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 
@@ -9,6 +8,6 @@ public interface MemberCommandService {
     
     KakaoDTO processKakaoLogin(HttpServletRequest request);
 
-    UUID deleteMember(UUID memberId, Member currentMember); // 회원 탈퇴는 다음 issue
+    UUID deleteMember(UUID memberId);
     
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
@@ -34,7 +34,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 	}
 	
 	@Override
-	public UUID deleteMember(UUID memberId, Member currentMember) {
+	public UUID deleteMember(UUID memberId) {
+		Member currentMember = memberManager.findMemberById(memberId);
+		
 		return memberManager.deleteMember(memberId, currentMember);
 	}
 	

--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
@@ -3,6 +3,7 @@ package com.midas.shootpointer.domain.member.business.command;
 import com.midas.shootpointer.domain.member.business.MemberManager;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
 import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 	private final MemberManager memberManager;
 	private final KakaoService kakaoService;
 	private final TokenService tokenService;
+	private final JwtUtil jwtUtil;
 	
 	
 	@Override
@@ -34,7 +36,10 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 	}
 	
 	@Override
-	public UUID deleteMember(UUID memberId) {
+	public UUID deleteMember(HttpServletRequest request) {
+		String token = jwtUtil.resolveToken(request);
+		UUID memberId = jwtUtil.getMemberId(token);
+		
 		Member currentMember = memberManager.findMemberById(memberId);
 		
 		return memberManager.deleteMember(memberId, currentMember);

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -4,6 +4,7 @@ import com.midas.shootpointer.domain.member.business.command.MemberCommandServic
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
 import com.midas.shootpointer.global.annotation.CustomLog;
+import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,16 +36,10 @@ public class MemberCommandController {
     
     @CustomLog("회원 탈퇴")
     @DeleteMapping
-    public ResponseEntity<MsgEntity> deleteMember(HttpServletRequest request) {
-        // JWT에서 memberId 추출
-        String token = jwtUtil.resolveToken(request);
-        UUID memberId = jwtUtil.getMemberId(token);
+    public ResponseEntity<ApiResponse<UUID>> deleteMember(HttpServletRequest request) {
+        UUID deletedMemberId = memberCommandService.deleteMember(request);
         
-        UUID deletedMemberId = memberCommandService.deleteMember(memberId);
-        
-        return ResponseEntity.ok(
-            new MsgEntity("회원 탈퇴가 완료되었습니다.", deletedMemberId)
-        );
+        return ResponseEntity.ok(ApiResponse.ok(deletedMemberId));
     }
     
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -1,16 +1,16 @@
 package com.midas.shootpointer.domain.member.controller;
 
-import com.midas.shootpointer.domain.member.business.MemberManager;
-import com.midas.shootpointer.domain.member.business.command.KakaoService;
 import com.midas.shootpointer.domain.member.business.command.MemberCommandService;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
-import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
 import com.midas.shootpointer.global.annotation.CustomLog;
+import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberCommandController {
     
     private final MemberCommandService memberCommandService;
+    private final JwtUtil jwtUtil;
     
     @CustomLog("카카오 소셜 로그인 및 JWT 발급")
     @GetMapping("/callback")
@@ -30,6 +31,20 @@ public class MemberCommandController {
         // 모든 비즈니스 로직은 Service Layer에서 처리
         KakaoDTO kakaoInfo = memberCommandService.processKakaoLogin(request);
         return ResponseEntity.ok().body(new MsgEntity("Success", kakaoInfo));
+    }
+    
+    @CustomLog("회원 탈퇴")
+    @DeleteMapping
+    public ResponseEntity<MsgEntity> deleteMember(HttpServletRequest request) {
+        // JWT에서 memberId 추출
+        String token = jwtUtil.resolveToken(request);
+        UUID memberId = jwtUtil.getMemberId(token);
+        
+        UUID deletedMemberId = memberCommandService.deleteMember(memberId);
+        
+        return ResponseEntity.ok(
+            new MsgEntity("회원 탈퇴가 완료되었습니다.", deletedMemberId)
+        );
     }
     
 }

--- a/src/main/java/com/midas/shootpointer/global/config/SecurityConfig.java
+++ b/src/main/java/com/midas/shootpointer/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 public class SecurityConfig {
     
     private final JwtHandler jwtHandler;
+    private final JwtUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -31,7 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/**", "/oauth/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtHandler),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtHandler, jwtUtil),
                         org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class
                 )
                 .httpBasic(Customizer.withDefaults());

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/JwtAuthenticationFilter.java
@@ -10,7 +10,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -21,6 +20,7 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private final JwtHandler jwtHandler;
+    private final JwtUtil jwtUtil;
     
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -28,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         FilterChain filterChain)
         throws ServletException, IOException {
         
-        String token = resolveToken(request);
+        String token = jwtUtil.resolveToken(request);
         
         if (token != null && jwtHandler.validateToken(token)) {
             try {
@@ -47,15 +47,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         
         filterChain.doFilter(request, response);
-    }
-    
-    // request 헤더에서 JWT 추출
-    private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-        return null;
     }
     
 }

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/JwtUtil.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/JwtUtil.java
@@ -10,8 +10,7 @@ import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
@@ -84,7 +83,14 @@ public class JwtUtil {
             throw new CustomException(ErrorCode.JWT_CREATE_FAIL);
         }
     }
-
+    
+    public String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
 
     public String decodeBase64(String encoded) {
         return new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #93 

---

## ✅ 작업 사항
1. 이전 리팩토링 이슈에서 구현한 `deleteMember` 메서드를 기반으로 **회원 탈퇴 API** 구현
2. 회원 정보 조회 시 `JwtAuthenticationFilter`의 `resolveToken` 메서드가 `private`으로 선언되어 있어 **Request에서 토큰을 추출 후 사용자 정보를 조회할 수 없는 문제** 발견.
3. 해당 메서드를 `public`으로 변경하고, `JwtAuthenticationFilter` → `JwtUtil` 로 이동하여 **재사용성** 개선.
4. 해당 과정에서 `SecurityConfig`에 **Filter 로직 반영**.

---

## ⌨ 기타