### PR TITLE
🌟 Feature : CustomUserDetails 관련 클래스 구현

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandService.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.member.business.command;
 
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
+import com.midas.shootpointer.domain.member.entity.Member;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 
@@ -8,6 +9,7 @@ public interface MemberCommandService {
     
     KakaoDTO processKakaoLogin(HttpServletRequest request);
 
-    UUID deleteMember(HttpServletRequest request);
+//    UUID deleteMember(HttpServletRequest request);
     
+    UUID deleteMember(Member member);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/MemberCommandServiceImpl.java
@@ -3,7 +3,6 @@ package com.midas.shootpointer.domain.member.business.command;
 import com.midas.shootpointer.domain.member.business.MemberManager;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
 import com.midas.shootpointer.domain.member.entity.Member;
-import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +17,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 	private final MemberManager memberManager;
 	private final KakaoService kakaoService;
 	private final TokenService tokenService;
-	private final JwtUtil jwtUtil;
-	
 	
 	@Override
 	public KakaoDTO processKakaoLogin(HttpServletRequest request) {
@@ -35,17 +32,22 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 		return kakaoInfo;
 	}
 	
-	@Override
-	public UUID deleteMember(HttpServletRequest request) {
-		String token = jwtUtil.resolveToken(request);
-		UUID memberId = jwtUtil.getMemberId(token);
-		
-		Member currentMember = memberManager.findMemberById(memberId);
-		
-		return memberManager.deleteMember(memberId, currentMember);
-	}
-	
+//	@Override
+//	public UUID deleteMember(HttpServletRequest request) {
+//		String token = jwtUtil.resolveToken(request);
+//		UUID memberId = jwtUtil.getMemberId(token);
+//
+//		Member currentMember = memberManager.findMemberById(memberId);
+//
+//		return memberManager.deleteMember(memberId, currentMember);
+//	}
+
 	private String extractCodeFromRequest(HttpServletRequest request) {
 		return request.getParameter("code");
+	}
+	
+	@Override
+	public UUID deleteMember(Member member) {
+		return memberManager.deleteMember(member.getMemberId(), member);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -6,12 +6,14 @@ import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import com.midas.shootpointer.global.dto.ApiResponse;
+import com.midas.shootpointer.global.security.CustomUserDetails;
 import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,9 +38,10 @@ public class MemberCommandController {
     
     @CustomLog("회원 탈퇴")
     @DeleteMapping
-    public ResponseEntity<ApiResponse<UUID>> deleteMember(HttpServletRequest request) {
-        UUID deletedMemberId = memberCommandService.deleteMember(request);
-        
+    public ResponseEntity<ApiResponse<UUID>> deleteMember(@AuthenticationPrincipal
+        CustomUserDetails userDetails) {
+        Member member = userDetails.getMember();
+        UUID deletedMemberId = memberCommandService.deleteMember(member);
         return ResponseEntity.ok(ApiResponse.ok(deletedMemberId));
     }
     

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -2,10 +2,11 @@ package com.midas.shootpointer.domain.member.controller;
 
 import com.midas.shootpointer.domain.member.business.command.MemberCommandService;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
+import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import com.midas.shootpointer.global.dto.ApiResponse;
-import com.midas.shootpointer.global.util.jwt.JwtUtil;
+import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
@@ -19,12 +20,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/kakao")
+@RequestMapping("/kakao") // RequestMapping API 엔드포인트 수정할 필요가 있어보임,,, -> 카카오 디벨로퍼스에서도 수정해야함
 @Tag(name = "회원 관리", description = "회원 관리 API")
 public class MemberCommandController {
     
     private final MemberCommandService memberCommandService;
-    private final JwtUtil jwtUtil;
     
     @CustomLog("카카오 소셜 로그인 및 JWT 발급")
     @GetMapping("/callback")
@@ -42,4 +42,11 @@ public class MemberCommandController {
         return ResponseEntity.ok(ApiResponse.ok(deletedMemberId));
     }
     
+    @CustomLog("회원 정보 조회")
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<Member>> getCurrentMember() {
+        Member currentMember = SecurityUtils.getCurrentMember();
+        
+        return ResponseEntity.ok(ApiResponse.ok(currentMember));
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.member.controller;
 
 import com.midas.shootpointer.domain.member.business.command.MemberCommandService;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
+import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
 import com.midas.shootpointer.global.annotation.CustomLog;
@@ -47,9 +48,13 @@ public class MemberCommandController {
     
     @CustomLog("회원 정보 조회")
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<Member>> getCurrentMember() {
+    public MemberResponseDto getCurrentMember() {
         Member currentMember = SecurityUtils.getCurrentMember();
-        
-        return ResponseEntity.ok(ApiResponse.ok(currentMember));
+		
+		return MemberResponseDto.builder()
+			.memberId(currentMember.getMemberId())
+			.email(currentMember.getEmail())
+			.username(currentMember.getUsername())
+			.build();
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberQueryController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "회원 조회", description = "회원 조회 API")
 public class MemberQueryController {
 	
+	//* TODO : 회원 조회 API는 삭제 예정
+	
 	private final MemberQueryService memberQueryService;
 	private final MemberMapper memberMapper;
 	

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -85,7 +85,7 @@ public enum ErrorCode {
 
     // 502(backnumber - service) part
     //* TODO : 현재 멤버 관련 로직이 Kakao 밖에 없어서 Member 도메인에 예외처리가 처음 생긴게 BackNumber 도메인임. << 이 부분은 추후에 Member 도메인에 로직 생기면 바꿀게요~
-    MEMBER_NOT_FOUND(50201, HttpStatus.NOT_FOUND, "Member를 찾을 수 없음"),
+    MEMBER_NOT_FOUND(50201, HttpStatus.NOT_FOUND, "Member를 찾을 수 없음."),
 
 
     //706(like - helper)

--- a/src/main/java/com/midas/shootpointer/global/config/SecurityConfig.java
+++ b/src/main/java/com/midas/shootpointer/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.global.config;
 
+import com.midas.shootpointer.global.security.CustomUserDetailsService;
 import com.midas.shootpointer.global.util.jwt.JwtAuthenticationFilter;
 import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import com.midas.shootpointer.global.util.jwt.handler.JwtHandler;
@@ -22,6 +23,7 @@ public class SecurityConfig {
     
     private final JwtHandler jwtHandler;
     private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -32,7 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/**", "/oauth/**").permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtHandler, jwtUtil),
+                .addFilterBefore(new JwtAuthenticationFilter(jwtHandler, jwtUtil, customUserDetailsService),
                         org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class
                 )
                 .httpBasic(Customizer.withDefaults());

--- a/src/main/java/com/midas/shootpointer/global/security/CustomUserDetails.java
+++ b/src/main/java/com/midas/shootpointer/global/security/CustomUserDetails.java
@@ -1,0 +1,32 @@
+package com.midas.shootpointer.global.security;
+
+import com.midas.shootpointer.domain.member.entity.Member;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+	
+	private final Member member;
+	
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+	}
+	
+	@Override
+	public String getPassword() {
+		return "";
+	}
+	
+	@Override
+	public String getUsername() {
+		return member.getUsername();
+	}
+}

--- a/src/main/java/com/midas/shootpointer/global/security/CustomUserDetails.java
+++ b/src/main/java/com/midas/shootpointer/global/security/CustomUserDetails.java
@@ -29,4 +29,24 @@ public class CustomUserDetails implements UserDetails {
 	public String getUsername() {
 		return member.getUsername();
 	}
+	
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+	
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+	
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+	
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
 }

--- a/src/main/java/com/midas/shootpointer/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/midas/shootpointer/global/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.midas.shootpointer.global.security;
+
+import com.midas.shootpointer.domain.member.business.query.MemberQueryService;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomUserDetailsService implements UserDetailsService {
+	
+	private final MemberQueryService memberQueryService;
+	
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		Member member = memberQueryService.findByEmail(email)
+			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+		
+		return new CustomUserDetails(member);
+	}
+}

--- a/src/main/java/com/midas/shootpointer/global/security/SecurityUtils.java
+++ b/src/main/java/com/midas/shootpointer/global/security/SecurityUtils.java
@@ -21,8 +21,10 @@ public class SecurityUtils {
 	 */
 	public static Member getCurrentMember() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		if (authentication != null && authentication.getPrincipal()
-			instanceof CustomUserDetails) {
+		
+		if (authentication != null &&
+			authentication.isAuthenticated() &&
+			authentication.getPrincipal() instanceof CustomUserDetails) {
 			CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal(); // Object 타입을 반환하는데, 이를 CustomUserDetails로 Boxing
 			
 			return userDetails.getMember();

--- a/src/main/java/com/midas/shootpointer/global/security/SecurityUtils.java
+++ b/src/main/java/com/midas/shootpointer/global/security/SecurityUtils.java
@@ -1,0 +1,45 @@
+package com.midas.shootpointer.global.security;
+
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 어느 패키지 / 클래스에서 인증된 Member 객체를 사용할 수 있는 Security Utils 클래스
+ */
+
+@Component
+public class SecurityUtils {
+	
+	/**
+	 * Member 객체 반환하는 메서드
+	 * @return Member
+	 */
+	public static Member getCurrentMember() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication != null && authentication.getPrincipal()
+			instanceof CustomUserDetails) {
+			CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal(); // Object 타입을 반환하는데, 이를 CustomUserDetails로 Boxing
+			
+			return userDetails.getMember();
+		}
+		
+		throw new CustomException(ErrorCode.UNAUTHORIZED_MEMBER_ACCESS);
+		// 현재 인증된 Member 객체를 가져오지 못한다면 인증이 만료되었거나, 존재하지 않기 때문에 두 케이스 전부 인증되지 않은 것으로 간주
+	}
+	
+	/**
+	 * Member 객체의 해당 memberId를 가져오는 메서드
+	 * @return UUID
+	 */
+	public static UUID getCurrentMemberId() {
+		return getCurrentMember().getMemberId();
+	}
+	
+	// Member 객체의 이메일을 가져오는 메서드는 구현 필요시 구현할게요
+
+}

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.global.util.jwt;
 
+import com.midas.shootpointer.global.security.CustomUserDetailsService;
 import com.midas.shootpointer.global.util.jwt.handler.JwtHandler;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,7 +9,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -21,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     
     private final JwtHandler jwtHandler;
     private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
     
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -32,14 +35,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         
         if (token != null && jwtHandler.validateToken(token)) {
             try {
+                
                 String email = jwtHandler.getEmailFromToken(token);
                 
-                // 인증 객체를 생성하여 SecurityContext에 저장
-                User principal = new User(email, "", Collections.emptyList());
-                UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
-                SecurityContextHolder.getContext().setAuthentication(authentication);
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+                UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                    userDetails, null, userDetails.getAuthorities()
+                );
                 
+                authenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authenticationToken);
             } catch (Exception e) {
                 // 인증 실패 시 SecurityContext 초기화
                 SecurityContextHolder.clearContext();

--- a/src/test/java/com/midas/shootpointer/global/security/CustomUserDetailsServiceTest.java
+++ b/src/test/java/com/midas/shootpointer/global/security/CustomUserDetailsServiceTest.java
@@ -1,0 +1,64 @@
+package com.midas.shootpointer.global.security;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.midas.shootpointer.domain.member.business.query.MemberQueryService;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.exception.CustomException;
+import java.util.Optional;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@ExtendWith(MockitoExtension.class)
+class CustomUserDetailsServiceTest {
+	
+	@Mock
+	private MemberQueryService memberQueryService;
+	
+	@InjectMocks
+	private CustomUserDetailsService customUserDetailsService;
+	
+	@Test
+	@DisplayName("존재하는 이메일로 사용자 조회_SUCCESS")
+	void loadUserByUsername_ExistEmail_ReturnsCustomUserDetails() {
+		// given
+		String email = "test123@naver.com";
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email(email)
+			.username("test123")
+			.build();
+		when(memberQueryService.findByEmail(email)).thenReturn(Optional.of(member));
+		// when
+		UserDetails result = customUserDetailsService.loadUserByUsername(email);
+		// then
+		assertThat(result).isInstanceOf(CustomUserDetails.class);
+		CustomUserDetails customUserDetails = (CustomUserDetails) result;
+		assertThat(customUserDetails.getMember()).isEqualTo(member);
+		assertThat(customUserDetails.getUsername()).isEqualTo("test123");
+		assertThat(customUserDetails.getMember().getEmail()).isEqualTo(email);
+	}
+	
+	@Test
+	@DisplayName("존재하지 않는 이메일로 사용자 조회 시 예외 발생_FAILED")
+	void loadUserByUsername_NotExistEmail_ThrowsCustomException() {
+		// given
+		String email = "test123@naver.com";
+		when(memberQueryService.findByEmail(anyString())).thenReturn(Optional.empty());
+		
+		// when & then
+		assertThatThrownBy(() -> customUserDetailsService.loadUserByUsername(email))
+			.isInstanceOf(CustomException.class)
+			.hasMessage("Member를 찾을 수 없음."); // MEMBER_NOT_FOUND
+	}
+}

--- a/src/test/java/com/midas/shootpointer/global/security/SecurityUtilsTest.java
+++ b/src/test/java/com/midas/shootpointer/global/security/SecurityUtilsTest.java
@@ -1,0 +1,80 @@
+package com.midas.shootpointer.global.security;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("dev")
+class SecurityUtilsTest {
+	
+	private Member member;
+	private CustomUserDetails customUserDetails;
+	
+	@BeforeEach
+	void setUp() {
+		SecurityContextHolder.clearContext();
+		
+		member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test123@naver.com")
+			.username("test123")
+			.build();
+		
+		customUserDetails = new CustomUserDetails(member);
+	}
+	
+	@Test
+	@DisplayName("인증된 사용자 Member 객체 반환_SUCCESS")
+	void getCurrentMember_AuthenticatedUser_ReturnsMember() {
+		// given
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			customUserDetails, null, customUserDetails.getAuthorities()
+		);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		// when
+		Member result = SecurityUtils.getCurrentMember();
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getMemberId()).isEqualTo(member.getMemberId());
+		assertThat(result.getEmail()).isEqualTo("test123@naver.com");
+		assertThat(result.getUsername()).isEqualTo("test123");
+	}
+	
+	@Test
+	@DisplayName("인증되지 않은 사용자일 때 예외 발생_FAILED")
+	void getCurrentMember_NotAuthenticated_ThrowsException() {
+		// given
+		SecurityContextHolder.clearContext();
+		// when & then
+		assertThatThrownBy(() -> SecurityUtils.getCurrentMember())
+			.isInstanceOf(CustomException.class)
+			.hasMessage(ErrorCode.UNAUTHORIZED_MEMBER_ACCESS.getMessage());
+	}
+	
+	@Test
+	@DisplayName("getCurrentMemberId - 인증된 사용자 ID 반환_SUCCESS")
+	void getCurrentMemberId_Authenticated_User_ReturnsMemberId() {
+		// given
+		Authentication authentication = new UsernamePasswordAuthenticationToken(
+			customUserDetails, null, customUserDetails.getAuthorities()
+		);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+		// when
+		UUID result = SecurityUtils.getCurrentMemberId();
+		// then
+		assertThat(result).isEqualTo(member.getMemberId());
+	}
+	
+}


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #102 

---

## ✅ 작업 사항

### 🚨 기존 문제 사항 정의
- **JWT 토큰 기반 인증에서 매번 DB 조회 필요** : Controller/Service에서 JWT 토큰으로 부터 memberId를 추출하고, 해당 ID 값으로 매번 DB를 조회하여 Member 객체를 가져오는 비효율적인 구조
- **중복된 인증 로직** : 각 엔드포인트마다 `jwtUtil.resolveToken()` -> `jwtUtil.getMemberId()` -> `memberRepository.findById()` 패턴이 반복
- **Spring Security 기능 활용 X** : Spring Security의 `UserDetails`, `@AuthenticationPrincipal` 등의 기능을 활용하지 않음

### ➡️ CustomUserDetails 적용 후 개선점

#### 1. **Auth 아키텍처 개선**
- `CustomUserDetails` 구현으로 Member 객체를 직접 포함하는 인증 정보를 생성
- `CustomUserDetailsService`를 통해 JWT 토큰의 이메일 정보로 사용자 정보 조회 및 SecurityContext에 정보 저장
- JwtAuthenticationFilter에서 한 번의 DB 조회 후 SecurityContext에 Member 객체가 포함된 인증 정보 저장

#### 2. **성능 최적화**
- **기존 성능** : 매 요청마다 JWT 파싱 + DB 조회
- **개선 성능** : JwtAuthenticationFilter에서 1회 조회 후 Context 활용, 이 후 메모리에서 Member 객체에 접근

#### 3. **코드 간소화 및 표준화**
- **기존 방식**
```java
String token = jwtUtil.resolveToken(request);
UUID memberId = jwtUtil.getMemberId(token);
Member member = memberRepository.findByMemberId(memberId);
```

- **개선 방식**
```java
// 개선 방식 1: @AuthenticationPrincipal
public ResponseEntity<?> api(@AuthenticationPrincipal CustomUserDetails userDetails) {
    Member member = userDetails.getMember();
}

// 개선 방식 2: SecurityUtils
public ResponseEntity<?> api() {
    Member member = SecurityUtils.getCurrentMember();
}
```

---

## ⌨ 기타
