### PR TITLE
🧩 Fix : 로그인/회원가입 시 발생하는 Refresh Token 갱신 버그 수정

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/member/business/command/TokenServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/command/TokenServiceImpl.java
@@ -19,11 +19,17 @@ public class TokenServiceImpl implements TokenService {
 		// Access Token 생성
 		String accessToken = jwtHandler.createAccessToken(member);
 		
-		// Refresh Token 생성
-		String refreshToken = jwtHandler.createRefreshToken(member.getEmail());
+		// Refresh Token 생성 -> 기존에 존재하면 해당 Refresh Token 설정 / 만료 되었다면 새로운 Refresh Token 생성
+		String existingRefreshToken = refreshTokenHandler.getRefreshToken(member.getEmail())
+			.orElse(null);
+		String refreshToken;
 		
-		// Refresh Token Redis에 저장
-		refreshTokenHandler.saveRefreshToken(member.getEmail(), refreshToken);
+		if (existingRefreshToken != null && jwtHandler.validateToken(existingRefreshToken)) {
+			refreshToken = existingRefreshToken;
+		} else {
+			refreshToken = jwtHandler.createRefreshToken(member.getEmail());
+			refreshTokenHandler.saveRefreshToken(member.getEmail(), refreshToken);
+		}
 		
 		// DTO에 토큰 정보 설정
 		kakaoDTO.setAccessToken(accessToken);

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandler.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandler.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.global.util.jwt.handler;
 
 import com.midas.shootpointer.domain.member.entity.Member;
+import java.util.Date;
 import java.util.UUID;
 
 public interface JwtHandler {
@@ -10,4 +11,6 @@ public interface JwtHandler {
 	String getNicknameFromToken(String token);
 	UUID getMemberIdFromToken(String token);
 	boolean validateToken(String token);
+	Date getTokenExpiration(String token);
+	boolean isTokenExpired(String token, long threshHoldMs);
 }

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandler.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandler.java
@@ -1,7 +1,6 @@
 package com.midas.shootpointer.global.util.jwt.handler;
 
 import com.midas.shootpointer.domain.member.entity.Member;
-import java.util.Date;
 import java.util.UUID;
 
 public interface JwtHandler {
@@ -11,6 +10,4 @@ public interface JwtHandler {
 	String getNicknameFromToken(String token);
 	UUID getMemberIdFromToken(String token);
 	boolean validateToken(String token);
-	Date getTokenExpiration(String token);
-	boolean isTokenExpired(String token, long threshHoldMs);
 }

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandlerImpl.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandlerImpl.java
@@ -49,38 +49,4 @@ public class JwtHandlerImpl implements JwtHandler {
 			return false;
 		}
 	}
-	
-	/**
-	 * 토큰 만료시간 반환
-	 * @param token
-	 * @return
-	 */
-	@Override
-	public Date getTokenExpiration(String token) {
-		try {
-			Claims claims = jwtUtil.parseToken(token);
-			return claims.getExpiration();
-		} catch (Exception e) {
-			return null;
-		}
-	}
-	
-	/**
-	 * 토큰이 만료되었는지 확인
-	 * @param token
-	 * @param threshHoldMs
-	 * @return
-	 */
-	@Override
-	public boolean isTokenExpired(String token, long threshHoldMs) {
-		try {
-			Claims claims = jwtUtil.parseToken(token);
-			Date expiration = claims.getExpiration();
-			Date now = new Date();
-			
-			return expiration.getTime() - now.getTime() < threshHoldMs;
-		} catch (Exception e) {
-			return true; // 예외 터지면 만료된거임
-		}
-	}
 }

--- a/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandlerImpl.java
+++ b/src/main/java/com/midas/shootpointer/global/util/jwt/handler/JwtHandlerImpl.java
@@ -2,6 +2,8 @@ package com.midas.shootpointer.global.util.jwt.handler;
 
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.global.util.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -40,10 +42,45 @@ public class JwtHandlerImpl implements JwtHandler {
 	@Override
 	public boolean validateToken(String token) {
 		try {
-			jwtUtil.parseToken(token);
-			return true;
+			Claims claims = jwtUtil.parseToken(token);
+			Date expiration = claims.getExpiration();
+			return expiration.after(new Date());
 		} catch (Exception e) {
 			return false;
+		}
+	}
+	
+	/**
+	 * 토큰 만료시간 반환
+	 * @param token
+	 * @return
+	 */
+	@Override
+	public Date getTokenExpiration(String token) {
+		try {
+			Claims claims = jwtUtil.parseToken(token);
+			return claims.getExpiration();
+		} catch (Exception e) {
+			return null;
+		}
+	}
+	
+	/**
+	 * 토큰이 만료되었는지 확인
+	 * @param token
+	 * @param threshHoldMs
+	 * @return
+	 */
+	@Override
+	public boolean isTokenExpired(String token, long threshHoldMs) {
+		try {
+			Claims claims = jwtUtil.parseToken(token);
+			Date expiration = claims.getExpiration();
+			Date now = new Date();
+			
+			return expiration.getTime() - now.getTime() < threshHoldMs;
+		} catch (Exception e) {
+			return true; // 예외 터지면 만료된거임
 		}
 	}
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #104 

---

## ✅ 작업 사항

기존 구현 내용은 사용자가 로그인이나 회원가입을 진행할 시 새로운 `Refresh Token`을 생성하여 Redis에 **Set**을 하는 작업이었습니다. 하지만 `Refresh Token` 값은 **만료 시간 전까지 새로 바뀌면 안되기 때문에**, 이를 조건문을 통해 만료가 되었다면 새로 생성하여 Set하고 그렇지 않다면 기존 `Refresh Token`을 그대로 유지하는 작업을 진행했습니다.

---

## ⌨ 기타
