### PR TITLE
🌟 Feature : 댓글 작성 작업[ C ]  및 테스트 코드 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,5 @@ src/main/resources/docker-compose.yml
 src/main/resources/application-dev.yml
 src/main/resources/application.yml
 src/main/resources/application-test.yml
+src/main/resources/application-testdata.yml
 ## Test

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -19,7 +19,7 @@ public class CommentManager {
 		
 		postHelper.findPostByPostId(comment.getPost().getPostId()); // 게시물이 존재하는지만 확인
 		
-		commentHelper.isValidateCommentContent(comment.getContent()); // 댓글 validation 체크
+		commentHelper.validatePostExists(comment.getPost().getPostId()); // 댓글 validation 체크
 		
 		return commentHelper.save(comment).getCommentId();
 	}

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -1,0 +1,27 @@
+package com.midas.shootpointer.domain.comment.business;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.helper.CommentHelper;
+import com.midas.shootpointer.domain.post.helper.PostHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class CommentManager {
+	
+	private final CommentHelper commentHelper;
+	private final PostHelper postHelper;
+	
+	@Transactional
+	public Long save(Comment comment) {
+		
+		postHelper.findPostByPostId(comment.getPost().getPostId()); // 게시물이 존재하는지만 확인
+		
+		commentHelper.isValidateCommentContent(comment.getContent()); // 댓글 validation 체크
+		
+		return commentHelper.save(comment).getCommentId();
+	}
+	
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
@@ -1,0 +1,8 @@
+package com.midas.shootpointer.domain.comment.business.command;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+
+public interface CommentCommandService {
+	
+	Long create(Comment comment);
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
@@ -1,0 +1,21 @@
+package com.midas.shootpointer.domain.comment.business.command;
+
+import com.midas.shootpointer.domain.comment.business.CommentManager;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentCommandServiceImpl implements CommentCommandService {
+	
+	private final CommentManager commentManager;
+	
+	@Override
+	@Transactional
+	public Long create(Comment comment) {
+		return commentManager.save(comment);
+	}
+	
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -6,6 +6,7 @@ import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +23,14 @@ public class CommentCommandController {
 	
 	private final CommentCommandService commentCommandService;
 	private final CommentMapper commentMapper;
+	private final PostHelper postHelper;
 	
 	@PostMapping
 	public ResponseEntity<ApiResponse<Long>> create(@RequestBody CommentRequestDto requestDto) {
 		
 		Member member = SecurityUtils.getCurrentMember();
-		PostEntity postEntity = PostEntity.builder()
-			.postId(requestDto.getPostId())
-			.build();
+		
+		PostEntity postEntity = postHelper.findPostByPostId(requestDto.getPostId());
 		Comment comment = commentMapper.dtoToEntity(requestDto, member, postEntity);
 		
 		return ResponseEntity.ok(ApiResponse.created(commentCommandService.create(comment)));

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -1,0 +1,38 @@
+package com.midas.shootpointer.domain.comment.controller;
+
+import com.midas.shootpointer.domain.comment.business.command.CommentCommandService;
+import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.dto.ApiResponse;
+import com.midas.shootpointer.global.security.SecurityUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comment")
+@RequiredArgsConstructor
+public class CommentCommandController {
+	
+	private final CommentCommandService commentCommandService;
+	private final CommentMapper commentMapper;
+	
+	@PostMapping
+	public ResponseEntity<ApiResponse<Long>> create(@RequestBody CommentRequestDto requestDto) {
+		
+		Member member = SecurityUtils.getCurrentMember();
+		PostEntity postEntity = PostEntity.builder()
+			.postId(requestDto.getPostId())
+			.build();
+		Comment comment = commentMapper.dtoToEntity(requestDto, member, postEntity);
+		
+		return ResponseEntity.ok(ApiResponse.created(commentCommandService.create(comment)));
+	}
+
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/CommentResponse.java
@@ -1,4 +1,0 @@
-package com.midas.shootpointer.domain.comment.dto;
-
-public class CommentResponse {
-}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentRequestDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentRequestDto.java
@@ -1,0 +1,23 @@
+package com.midas.shootpointer.domain.comment.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentRequestDto {
+	
+	@NotNull(message = "게시물 ID는 필수입니다.")
+	private Long postId;
+	
+	@NotBlank(message = "댓글 내용은 공백이 허용되지 않습니다.")
+	@Max(value = 500, message = "댓글 내용은 500자 이하만 입력 가능합니다.")
+	private String content;
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponse.java
@@ -1,0 +1,4 @@
+package com.midas.shootpointer.domain.comment.dto.response;
+
+public class CommentResponse {
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
@@ -1,0 +1,45 @@
+package com.midas.shootpointer.domain.comment.entity;
+
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Table(name = "comment")
+@SQLRestriction("is_deleted = false")
+@Getter
+@Builder
+public class Comment extends BaseEntity {
+
+	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "comment_id", unique = true, nullable = false)
+	private Long commentId;
+	
+	@Column(name = "content", columnDefinition = "TEXT", length = 500, nullable = false)
+	private String content;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "post_id", nullable = false)
+	private PostEntity post;
+	
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
@@ -1,0 +1,5 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+public interface CommentHelper extends CommentValidation, CommentUtil {
+
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -9,9 +9,10 @@ import org.springframework.stereotype.Component;
 public class CommentHelperImpl implements CommentHelper {
 	private final CommentValidation commentValidation;
 	private final CommentUtil commentUtil;
+	
 	@Override
-	public void isValidateCommentContent(String content) {
-		commentValidation.isValidateCommentContent(content);
+	public void validatePostExists(Long postId) {
+		commentValidation.validatePostExists(postId);
 	}
 	
 	@Override

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -1,0 +1,21 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentHelperImpl implements CommentHelper {
+	private final CommentValidation commentValidation;
+	private final CommentUtil commentUtil;
+	@Override
+	public void isValidateCommentContent(String content) {
+		commentValidation.isValidateCommentContent(content);
+	}
+	
+	@Override
+	public Comment save(Comment comment) {
+		return commentUtil.save(comment);
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
@@ -1,0 +1,8 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+
+public interface CommentUtil {
+	
+	Comment save(Comment comment);
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
@@ -1,0 +1,18 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.repository.command.CommentCommandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentUtilImpl implements CommentUtil {
+	
+	private final CommentCommandRepository commentCommandRepository;
+	
+	@Override
+	public Comment save(Comment comment) {
+		return commentCommandRepository.save(comment);
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
@@ -2,5 +2,5 @@ package com.midas.shootpointer.domain.comment.helper;
 
 public interface CommentValidation {
 	
-	void isValidateCommentContent(String content);
+	void validatePostExists(Long postId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
@@ -1,0 +1,6 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+public interface CommentValidation {
+	
+	void isValidateCommentContent(String content);
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.comment.helper;
 
+import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -9,10 +10,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CommentValidationImpl implements CommentValidation {
 	
+	private final PostHelper postHelper;
+	
 	@Override
-	public void isValidateCommentContent(String content) {
-		if (content == null || content.trim().isEmpty()) { // 유효성 검사 시 댓글이 null 이거나 trim으로 공백 제거 후 비어있으면 예외 던지기
-			throw new CustomException(ErrorCode.INVALID_COMMENT_CONTENT);
+	public void validatePostExists(Long postId) {
+		try {
+			postHelper.findPostByPostId(postId);
+		} catch (Exception e) {
+			throw new CustomException(ErrorCode.IS_NOT_EXIST_POST);
 		}
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
@@ -1,0 +1,18 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CommentValidationImpl implements CommentValidation {
+	
+	@Override
+	public void isValidateCommentContent(String content) {
+		if (content == null || content.trim().isEmpty()) { // 유효성 검사 시 댓글이 null 이거나 trim으로 공백 제거 후 비어있으면 예외 던지기
+			throw new CustomException(ErrorCode.INVALID_COMMENT_CONTENT);
+		}
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapper.java
@@ -1,0 +1,11 @@
+package com.midas.shootpointer.domain.comment.mapper;
+
+import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+
+public interface CommentMapper {
+	
+	Comment dtoToEntity(CommentRequestDto commentRequestDto, Member member, PostEntity post);
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
@@ -1,0 +1,21 @@
+package com.midas.shootpointer.domain.comment.mapper;
+
+import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CommentMapperImpl implements CommentMapper {
+	
+	@Override
+	public Comment dtoToEntity(CommentRequestDto commentRequestDto, Member member,
+		PostEntity post) {
+		return Comment.builder()
+			.content(commentRequestDto.getContent())
+			.member(member)
+			.post(post)
+			.build();
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/repository/command/CommentCommandRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/repository/command/CommentCommandRepository.java
@@ -1,0 +1,10 @@
+package com.midas.shootpointer.domain.comment.repository.command;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentCommandRepository extends JpaRepository<Comment, Long> {
+
+}

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -20,8 +20,7 @@ public enum ErrorCode {
      * backnumber :                50
      * post:                       60
      * like:                       70
-     * backNumber:                 50
-     * post:                       60
+     * comment:                    80
 
      * <p>
      * - Package
@@ -105,9 +104,10 @@ public enum ErrorCode {
     NOT_EXIST_ORDER_TYPE(60603,HttpStatus.BAD_REQUEST,"잘못된 조회 방식입니다."),
 
     //607(post-business) part
-    IS_NOT_EXIST_POST(60701,HttpStatus.FORBIDDEN,"존재하지 않는 게시물입니다.")
-    ;
+    IS_NOT_EXIST_POST(60701,HttpStatus.FORBIDDEN,"존재하지 않는 게시물입니다."),
 
+    // 806(comment - helper) part
+    INVALID_COMMENT_CONTENT(80601, HttpStatus.BAD_REQUEST, "유효하지 않은 댓글 내용입니다.");
 
 
     private final Integer code;

--- a/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
@@ -5,6 +5,7 @@ import com.midas.shootpointer.domain.highlight.repository.HighlightCommandReposi
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.repository.MemberCommandRepository;
 import com.midas.shootpointer.domain.post.entity.HashTag;
+import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -26,9 +27,10 @@ public class DummyDataLoader implements CommandLineRunner {
     private final MakeRandomWord makeRandomWord;
     private final MemberCommandRepository memberRepository;
     private final HighlightCommandRepository highlightCommandRepository;
-
+    private final JwtUtil jwtUtil;
+    
     private final int batchSize=10_000;
-    private final int insertSize=10_000_000;
+    private final int insertSize=10_000;
 
     @Override
     public void run(String... args) throws Exception {
@@ -37,7 +39,10 @@ public class DummyDataLoader implements CommandLineRunner {
                 .username("test")
                 .build()
         );
-
+        
+        String accessToken = jwtUtil.createToken(member.getMemberId(), member.getEmail(),
+            member.getUsername());
+        
         HighlightEntity highlight=highlightCommandRepository.save(
                 HighlightEntity.builder()
                         .highlightURL("test")
@@ -81,8 +86,8 @@ public class DummyDataLoader implements CommandLineRunner {
                 batchArgs.clear();
                 System.out.println(i+"건 삽입 완료");
             }
-
         }
+        System.out.println("Access Token : " + accessToken);
 
         if (!batchArgs.isEmpty()){
             jdbcTemplate.batchUpdate(sql,batchArgs);

--- a/src/main/java/com/midas/shootpointer/test/MakeRandomWord.java
+++ b/src/main/java/com/midas/shootpointer/test/MakeRandomWord.java
@@ -28,7 +28,7 @@ public class MakeRandomWord {
 
     public String generateTitle() {
         // 2~5개의 랜덤 단어로 제목 생성
-        int wordCount = 10 + random.nextInt(4);
+        int wordCount = 1 + random.nextInt(2);
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < wordCount; i++) {
             sb.append(TITLES[random.nextInt(TITLES.length)]);

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -1,0 +1,158 @@
+package com.midas.shootpointer.domain.comment.business;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.helper.CommentHelper;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.domain.post.helper.PostHelper;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentManager 테스트")
+class CommentManagerTest {
+	
+	@Mock
+	private CommentHelper commentHelper;
+	
+	@Mock
+	private PostHelper postHelper;
+	
+	@InjectMocks
+	private CommentManager commentManager;
+	
+	@Test
+	@DisplayName("댓글 저장 성공")
+	void comment_save_success() {
+		// given
+		Comment comment = createComment();
+		Comment savedComment = Comment.builder()
+			.commentId(1L)
+			.content(comment.getContent())
+			.member(comment.getMember())
+			.post(comment.getPost())
+			.build();
+		
+		given(postHelper.findPostByPostId(anyLong())).willReturn(comment.getPost());
+		willDoNothing().given(commentHelper).isValidateCommentContent(anyString());
+		given(commentHelper.save(any(Comment.class))).willReturn(savedComment);
+		
+		// when
+		Long result = commentManager.save(comment);
+		
+		// then
+		assertThat(result).isEqualTo(1L);
+		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
+		then(commentHelper).should().isValidateCommentContent(comment.getContent());
+		then(commentHelper).should().save(comment);
+	}
+	
+	@Test
+	@DisplayName("존재하지 않는 게시물에 댓글 작성 -> 에외 발생")
+	void save_IS_NOT_EXIST_POST_ThrowException() {
+		// given
+		Comment comment = createComment();
+		
+		given(postHelper.findPostByPostId(anyLong())).willThrow(
+			new CustomException(ErrorCode.IS_NOT_EXIST_POST)
+		);
+		
+		// when-then
+		assertThatThrownBy(() -> commentManager.save(comment))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
+		
+		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
+		then(commentHelper).shouldHaveNoInteractions();
+	}
+	
+	@Test
+	@DisplayName("유효하지 않은 댓글 내용으로 저장 -> 예외 발생")
+	void save_Invalid_Content_ThrowException() {
+		// given
+		Comment comment = createComment();
+		
+		given(postHelper.findPostByPostId(anyLong())).willReturn(comment.getPost());
+		willThrow(new CustomException(ErrorCode.INVALID_COMMENT_CONTENT))
+			.given(commentHelper).isValidateCommentContent(anyString());
+		
+		// when-then
+		assertThatThrownBy(() -> commentManager.save(comment))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_COMMENT_CONTENT);
+		
+		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
+		then(commentHelper).should().isValidateCommentContent(comment.getContent());
+		then(commentHelper).should(never()).save(any(Comment.class));
+	}
+	
+	@Test
+	@DisplayName("댓글 저장 실패 - Comment가 Null인 경우")
+	void save_Failed_NullComment() {
+		// given
+		Comment comment = null;
+		
+		// when-then
+		assertThatThrownBy(() -> commentManager.save(comment))
+			.isInstanceOf(NullPointerException.class);
+	}
+	
+	@Test
+	@DisplayName("댓글 저장 실패 - Comment에 Post가 Null인 경우")
+	void save_Failed_CommentPostIsNull() {
+		// given
+		Comment comment = Comment.builder()
+			.content("테스트 댓글")
+			.member(createMember())
+			.post(null)
+			.build();
+		
+		// when-then
+		assertThatThrownBy(() -> commentManager.save(comment))
+			.isInstanceOf(NullPointerException.class);
+	}
+	
+	private Comment createComment() {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@test.com")
+			.username("testUser")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		return Comment.builder()
+			.content("테스트 댓글입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+	
+	private Member createMember() {
+		return Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@test.com")
+			.username("testUser")
+			.build();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentManager 테스트")
+@SpringBootTest
 class CommentManagerTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -109,17 +109,6 @@ class CommentManagerTest {
 	}
 	
 	@Test
-	@DisplayName("댓글 저장 실패 - Comment가 Null인 경우")
-	void save_Failed_NullComment() {
-		// given
-		Comment comment = null;
-		
-		// when-then
-		assertThatThrownBy(() -> commentManager.save(comment))
-			.isInstanceOf(NullPointerException.class);
-	}
-	
-	@Test
 	@DisplayName("댓글 저장 실패 - Comment에 Post가 Null인 경우")
 	void save_Failed_CommentPostIsNull() {
 		// given

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -26,10 +26,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentManager 테스트")
-@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
+@Rollback
 class CommentManagerTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -32,9 +32,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentManager 테스트")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@Transactional
-@Rollback
 class CommentManagerTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -50,19 +50,6 @@ class CommentCommandServiceImplTest {
 		then(commentManager).should().save(comment);
 	}
 	
-	@Test
-	@DisplayName("댓글 생성 실패 - Comment가 Null인 경우")
-	void create_Failed_NullComment() {
-		// given
-		Comment comment = null;
-		
-		// when-then
-		assertThatThrownBy(() -> commentCommandService.create(comment))
-			.isInstanceOf(Exception.class); // NullPointerException이나 다른 예외 발생 가능
-		
-		then(commentManager).should().save(comment);
-	}
-	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(UUID.randomUUID())

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -18,9 +18,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentCommandService 테스트")
+@SpringBootTest
 class CommentCommandServiceImplTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -19,10 +19,15 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentCommandService 테스트")
-@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
+@Rollback
 class CommentCommandServiceImplTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -1,0 +1,79 @@
+package com.midas.shootpointer.domain.comment.business.command;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.midas.shootpointer.domain.comment.business.CommentManager;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentCommandService 테스트")
+class CommentCommandServiceImplTest {
+	
+	@Mock
+	private CommentManager commentManager;
+	
+	@InjectMocks
+	private CommentCommandServiceImpl commentCommandService;
+	
+	@Test
+	@DisplayName("댓글 생성 성공")
+	void create_success() {
+		// given
+		Comment comment = createComment();
+		Long expectedCommentId = 1L;
+		
+		given(commentManager.save(any(Comment.class))).willReturn(expectedCommentId);
+		
+		// when
+		Long result = commentCommandService.create(comment);
+		
+		// then
+		assertThat(result).isEqualTo(expectedCommentId);
+		then(commentManager).should().save(comment);
+	}
+	
+	@Test
+	@DisplayName("댓글 생성 실패 - Comment가 Null인 경우")
+	void create_Failed_NullComment() {
+		// given
+		Comment comment = null;
+		
+		// when-then
+		assertThatThrownBy(() -> commentCommandService.create(comment))
+			.isInstanceOf(Exception.class); // NullPointerException이나 다른 예외 발생 가능
+		
+		then(commentManager).should().save(comment);
+	}
+	
+	private Comment createComment() {
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		return Comment.builder()
+			.content("테스트입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -25,9 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentCommandService 테스트")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@Transactional
-@Rollback
 class CommentCommandServiceImplTest {
 	
 	@Mock

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
@@ -1,0 +1,169 @@
+package com.midas.shootpointer.domain.comment.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.midas.shootpointer.domain.comment.business.command.CommentCommandService;
+import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.domain.post.helper.PostHelper;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import com.midas.shootpointer.global.security.SecurityUtils;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CommentCommandController.class)
+@DisplayName("CommentCommandController 테스트")
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class CommentCommandControllerTest {
+	
+	@Autowired
+	private MockMvc mockMvc;
+	
+	@Autowired
+	private ObjectMapper objectMapper;
+	
+	@MockitoBean
+	private CommentCommandService commentCommandService;
+	
+	@MockitoBean
+	private CommentMapper commentMapper;
+	
+	@MockitoBean
+	private PostHelper postHelper;
+	
+	@Test
+	@DisplayName("댓글 생성 성공")
+	void create_Success() throws Exception {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content("테스트 댓글입니다.")
+			.build();
+		
+		Member member = createMember();
+		PostEntity postEntity = createPostEntity();
+		Comment comment = createComment();
+		Long savedCommentId = 1L;
+		
+		try (MockedStatic<SecurityUtils> securityUtilsMock = Mockito.mockStatic(SecurityUtils.class)) {
+			securityUtilsMock.when(SecurityUtils::getCurrentMember).thenReturn(member);
+			given(postHelper.findPostByPostId(1L)).willReturn(postEntity);
+			given(commentMapper.dtoToEntity(requestDto, member, postEntity)).willReturn(comment);
+			given(commentCommandService.create(comment)).willReturn(savedCommentId);
+			
+			// when-then
+			mockMvc.perform(post("/api/comment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data").value(1L));
+			
+			then(postHelper).should().findPostByPostId(1L);
+			then(commentMapper).should().dtoToEntity(requestDto, member, postEntity);
+			then(commentCommandService).should().create(comment);
+		}
+	}
+	
+	@Test
+	@DisplayName("댓글 생성 실패 - 존재하지 않는 게시물")
+	void create_PostNotFound() throws Exception {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(999L)
+			.content("테스트 댓글입니다.")
+			.build();
+		
+		Member member = createMember();
+		
+		try (MockedStatic<SecurityUtils> securityUtilsMock = Mockito.mockStatic(SecurityUtils.class)) {
+			securityUtilsMock.when(SecurityUtils::getCurrentMember).thenReturn(member);
+			given(postHelper.findPostByPostId(999L))
+				.willThrow(new CustomException(ErrorCode.IS_NOT_EXIST_POST));
+			
+			// when-then
+			mockMvc.perform(post("/api/comment")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(requestDto)))
+				.andExpect(status().isBadRequest());
+			
+			then(postHelper).should().findPostByPostId(999L);
+		}
+	}
+	
+	@Test
+	@DisplayName("댓글 생성 실패 - 빈 내용")
+	void create_EmptyContent() throws Exception {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content("")
+			.build();
+		
+		// when-then
+		mockMvc.perform(post("/api/comment")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andExpect(status().isBadRequest());
+	}
+	
+	@Test
+	@DisplayName("댓글 생성 실패 - null 내용")
+	void create_NullContent() throws Exception {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content(null)
+			.build();
+		
+		// when-then
+		mockMvc.perform(post("/api/comment")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(requestDto)))
+			.andExpect(status().isBadRequest());
+	}
+	
+	private Member createMember() {
+		return Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+	}
+	
+	private PostEntity createPostEntity() {
+		return PostEntity.builder()
+			.postId(1L)
+			.build();
+	}
+	
+	private Comment createComment() {
+		return Comment.builder()
+			.content("테스트입니다.")
+			.member(createMember())
+			.post(createPostEntity())
+			.build();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
@@ -1,0 +1,106 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentHelper 테스트")
+class CommentHelperImplTest {
+	
+	@Mock
+	private CommentValidation commentValidation;
+	
+	@Mock
+	private CommentUtil commentUtil;
+	
+	@InjectMocks
+	private CommentHelperImpl commentHelper;
+	
+	@Test
+	@DisplayName("게시물 존재 여부 검증 성공")
+	void validatePostExists_Success() {
+		// given
+		Long postId = 1L;
+		willDoNothing().given(commentValidation).validatePostExists(postId);
+		
+		// when-then
+		assertThatNoException().isThrownBy(() -> commentHelper.validatePostExists(postId));
+		then(commentValidation).should().validatePostExists(postId);
+	}
+	
+	@Test
+	@DisplayName("게시물 존재 여부 검증 실패 - 예외 발생")
+	void validatePostExists_ThrowException() {
+		// given
+		Long postId = 999_999_9L;
+		willThrow(new CustomException(ErrorCode.IS_NOT_EXIST_POST))
+			.given(commentValidation).validatePostExists(postId);
+		
+		// when-then
+		assertThatThrownBy(() -> commentHelper.validatePostExists(postId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
+		
+		then(commentValidation).should().validatePostExists(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 저장 성공")
+	void save_Success() {
+		// given
+		Comment comment = createComment();
+		Comment savedComment = Comment.builder()
+			.commentId(1L)
+			.content(comment.getContent())
+			.member(comment.getMember())
+			.post(comment.getPost())
+			.build();
+		
+		given(commentUtil.save(comment)).willReturn(savedComment);
+		
+		// when
+		Comment result = commentHelper.save(comment);
+		
+		// then
+		assertThat(result).isEqualTo(savedComment);
+		assertThat(result.getCommentId()).isEqualTo(1L);
+		then(commentUtil).should().save(comment);
+	}
+	
+	private Comment createComment() {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		return Comment.builder()
+			.content("테스트입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+	
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
@@ -1,0 +1,72 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.repository.command.CommentCommandRepository;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentUtil 테스트")
+class CommentUtilImplTest {
+	
+	@Mock
+	private CommentCommandRepository commentCommandRepository;
+	
+	@InjectMocks
+	private CommentUtilImpl commentUtil;
+	
+	@Test
+	@DisplayName("댓글 저장 성공")
+	void save_Success() {
+		// given
+		Comment comment = createComment();
+		Comment savedComment = Comment.builder()
+			.commentId(1L)
+			.content(comment.getContent())
+			.member(comment.getMember())
+			.post(comment.getPost())
+			.build();
+		
+		given(commentCommandRepository.save(comment)).willReturn(savedComment);
+		
+		// when
+		Comment result = commentUtil.save(comment);
+		
+		// then
+		assertThat(result).isEqualTo(savedComment);
+		assertThat(result.getCommentId()).isEqualTo(1L);
+		assertThat(result.getContent()).isEqualTo("테스트 댓글입니다.");
+		then(commentCommandRepository).should().save(comment);
+	}
+	
+	private Comment createComment() {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@test.com")
+			.username("testUser")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		return Comment.builder()
+			.content("테스트 댓글입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -21,9 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentValidation 테스트")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@Transactional
-@Rollback
 class CommentValidationImplTest {
 	
 	@InjectMocks

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -1,0 +1,46 @@
+package com.midas.shootpointer.domain.comment.helper;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentValidation 테스트")
+class CommentValidationImplTest {
+	
+	@InjectMocks
+	private CommentValidationImpl commentValidation;
+	
+	@Test
+	@DisplayName("유효한 댓글 내용 검증 성공")
+	void isValidateCommentContent_ValidContent_Success() {
+		// given
+		String validContent = "유효한 댓글 내용입니다.";
+		
+		// when-then
+		assertThatNoException().isThrownBy(() ->
+			commentValidation.isValidateCommentContent(validContent));
+	}
+	
+	@ParameterizedTest
+	@NullAndEmptySource
+	@ValueSource(strings = {"   ", "\t", "\n", "  \t  \n  "})
+	@DisplayName("null, 빈 문자열, 공백만 있는 댓글 내용은 유효하지 않음")
+	void isValidateCommentContent_InvalidContent_ThrowException(String invalidContent) {
+		// when-then
+		assertThatThrownBy(() -> commentValidation.isValidateCommentContent(invalidContent))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_COMMENT_CONTENT);
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -3,48 +3,72 @@ package com.midas.shootpointer.domain.comment.helper;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullAndEmptySource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentValidation 테스트")
 class CommentValidationImplTest {
 	
+	@Mock
+	private PostHelper postHelper;
+	
 	@InjectMocks
 	private CommentValidationImpl commentValidation;
 	
 	@Test
-	@DisplayName("유효한 댓글 내용 검증 성공")
-	void isValidateCommentContent_ValidContent_Success() {
+	@DisplayName("존재하는 게시물 검증 성공")
+	void validatePostExists_ValidPost_Success() {
 		// given
-		String validContent = "유효한 댓글 내용입니다.";
+		Long postId = 1L;
+		PostEntity postEntity = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		given(postHelper.findPostByPostId(postId)).willReturn(postEntity);
 		
 		// when-then
 		assertThatNoException().isThrownBy(() ->
-			commentValidation.isValidateCommentContent(validContent));
+			commentValidation.validatePostExists(postId));
 	}
 	
-	@ParameterizedTest
-	@NullAndEmptySource
-	@ValueSource(strings = {"   ", "\t", "\n", "  \t  \n  "})
-	@DisplayName("null, 빈 문자열, 공백만 있는 댓글 내용은 유효하지 않음")
-	void isValidateCommentContent_InvalidContent_ThrowException(String invalidContent) {
+	@Test
+	@DisplayName("존재하지 않는 게시물 검증 실패 - 예외 발생")
+	void validatePostExists_InvalidPost_ThrowException() {
+		// given
+		Long postId = 999L;
+		
+		given(postHelper.findPostByPostId(postId))
+			.willThrow(new CustomException(ErrorCode.IS_NOT_EXIST_POST));
+		
 		// when-then
-		assertThatThrownBy(() -> commentValidation.isValidateCommentContent(invalidContent))
+		assertThatThrownBy(() -> commentValidation.validatePostExists(postId))
 			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_COMMENT_CONTENT);
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
+	}
+	
+	@Test
+	@DisplayName("PostHelper에서 다른 예외 발생 시 IS_NOT_EXIST_POST로 변환")
+	void validatePostExists_PostHelperException_ConvertToPostNotFound() {
+		// given
+		Long postId = 1L;
+		
+		given(postHelper.findPostByPostId(postId))
+			.willThrow(new RuntimeException("Database connection error"));
+		
+		// when-then
+		assertThatThrownBy(() -> commentValidation.validatePostExists(postId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
 	}
 }

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -15,10 +15,15 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentValidation 테스트")
-@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
+@Rollback
 class CommentValidationImplTest {
 	
 	@InjectMocks

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -14,9 +14,11 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentValidation 테스트")
+@SpringBootTest
 class CommentValidationImplTest {
 	
 	@InjectMocks

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -14,8 +14,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
+@ActiveProfiles("dev")
 @DisplayName("CommentMapper 테스트")
 class CommentMapperImplTest {
 	

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -15,12 +15,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("dev")
 @DisplayName("CommentMapper 테스트")
-@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Transactional
+@Rollback
 class CommentMapperImplTest {
 	
 	@InjectMocks

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -14,14 +14,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
-@ActiveProfiles("dev")
 @DisplayName("CommentMapper 테스트")
 class CommentMapperImplTest {
 	

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -1,0 +1,124 @@
+package com.midas.shootpointer.domain.comment.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import java.util.UUID;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentMapper 테스트")
+class CommentMapperImplTest {
+	
+	@InjectMocks
+	private CommentMapperImpl commentMapper;
+	
+	@Test
+	@DisplayName("DTO -> Entity 변환 성공")
+	void dtoToEntity_Success() {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content("테스트입니다.")
+			.build();
+		
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		// when
+		Comment result = commentMapper.dtoToEntity(requestDto, member, post);
+		
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).isEqualTo(requestDto.getContent());
+		assertThat(result.getMember()).isEqualTo(member);
+		assertThat(result.getPost()).isEqualTo(post);
+		assertThat(result.getCommentId()).isNull();
+	}
+	
+	@Test
+	@DisplayName("DTO -> Entity 변환 실패 _ DTO가 Null인 경우")
+	void dtoToEntity_Failed_NullDTO() {
+		// given
+		CommentRequestDto requestDto = null;
+		
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		// when-then
+		assertThatThrownBy(() -> commentMapper.dtoToEntity(requestDto, member, post))
+			.isInstanceOf(NullPointerException.class);
+	}
+	
+	@Test
+	@DisplayName("DTO -> Entity 변환 실패 _ Member가 Null인 경우")
+	void dtoToEntity_Failed_NullMember() {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content("테스트입니다.")
+			.build();
+		
+		Member member = null;
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		// when
+		Comment result = commentMapper.dtoToEntity(requestDto, member, post);
+		
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).isEqualTo(requestDto.getContent());
+		assertThat(result.getMember()).isNull();
+		assertThat(result.getPost()).isEqualTo(post);
+	}
+	
+	@Test
+	@DisplayName("DTO -> Entity 변환 실패 - Post가 Null인 경우")
+	void dtoToEntity_Failed_NullPost() {
+		// given
+		CommentRequestDto requestDto = CommentRequestDto.builder()
+			.postId(1L)
+			.content("테스트입니다.")
+			.build();
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		PostEntity post = null;
+		
+		// when
+		Comment result = commentMapper.dtoToEntity(requestDto, member, post);
+		
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getContent()).isEqualTo(requestDto.getContent());
+		assertThat(result.getMember()).isEqualTo(member);
+		assertThat(result.getPost()).isNull();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -23,9 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("dev")
 @DisplayName("CommentMapper 테스트")
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-@Transactional
-@Rollback
 class CommentMapperImplTest {
 	
 	@InjectMocks

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -14,11 +14,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("dev")
 @DisplayName("CommentMapper 테스트")
+@SpringBootTest
 class CommentMapperImplTest {
 	
 	@InjectMocks


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #120 

---

## ✅ 작업 사항

- #95 

해당 더미 데이터 삽입을 통해 일일히 API 호출을 통한 데이터 삽입이 아닌 `@Profile("testdata")`를 통해 쉽게 댓글 작성 API 호출부터 테스트까지 진행하였습니다.

---

해당 작업에서 마찬가지로 **CQRS 패턴**을 적용하여 `댓글 작성`에 관련된 부분을 코드 구현하였습니다.

다만 테스트 코드의 경우 아직 해당 작업에 학습이 부족하여 추후 테스트 보완을 할 예정에 있습니다. 이 점을 감안하여 테스트 코드 관련 java 파일을 리뷰 후 피드백 해주시면 감사하겠습니다 🙂

- #119 

전체적인 작업이 다 완료된 후에 위의 **Issue PR**에서 댓글 플로우를 다루어 올리겠습니다.

---

## ⌨ 기타