### PR TITLE
🌟 Feature : 댓글 조회 작업[ R ] 및 테스트 코드 작업

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -28,7 +28,7 @@ public class CommentManager {
 	}
 	
 	@Transactional(readOnly = true)
-	public List<Comment> findCommentByPostId(Long postId) {
+	public List<Comment> findCommentsByPostId(Long postId) {
 		postHelper.findPostByPostId(postId);
 		
 		return commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId); // 최신순으로 댓글을 모두 조회

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -3,6 +3,7 @@ package com.midas.shootpointer.domain.comment.business;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.helper.CommentHelper;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,8 @@ public class CommentManager {
 	@Transactional
 	public Long save(Comment comment) {
 		
+		//* TODO : 첫 번째 코드와 아래 두 번째 코드가 사실상 같은 역할인데 다른 코드로 구현되어있음.
+		//* 도메인 역할 분리를 위해 따로 구현할 것인지 OR 그냥 하나로 통합할 것인지
 		postHelper.findPostByPostId(comment.getPost().getPostId()); // 게시물이 존재하는지만 확인
 		
 		commentHelper.validatePostExists(comment.getPost().getPostId()); // 댓글 validation 체크
@@ -24,4 +27,10 @@ public class CommentManager {
 		return commentHelper.save(comment).getCommentId();
 	}
 	
+	@Transactional(readOnly = true)
+	public List<Comment> findCommentByPostId(Long postId) {
+		postHelper.findPostByPostId(postId);
+		
+		return commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId); // 최신순으로 댓글을 모두 조회
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -17,12 +17,7 @@ public class CommentManager {
 	
 	@Transactional
 	public Long save(Comment comment) {
-		
-		//* TODO : 첫 번째 코드와 아래 두 번째 코드가 사실상 같은 역할인데 다른 코드로 구현되어있음.
-		//* 도메인 역할 분리를 위해 따로 구현할 것인지 OR 그냥 하나로 통합할 것인지
 		postHelper.findPostByPostId(comment.getPost().getPostId()); // 게시물이 존재하는지만 확인
-		
-		commentHelper.validatePostExists(comment.getPost().getPostId()); // 댓글 validation 체크
 		
 		return commentHelper.save(comment).getCommentId();
 	}

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryService.java
@@ -1,0 +1,9 @@
+package com.midas.shootpointer.domain.comment.business.query;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
+
+public interface CommentQueryService {
+	
+	List<Comment> getCommentsByPostId(Long postId);
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImpl.java
@@ -16,6 +16,6 @@ public class CommentQueryServiceImpl implements CommentQueryService {
 	@Override
 	@Transactional(readOnly = true)
 	public List<Comment> getCommentsByPostId(Long postId) {
-		return commentManager.findCommentByPostId(postId);
+		return commentManager.findCommentsByPostId(postId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImpl.java
@@ -1,0 +1,21 @@
+package com.midas.shootpointer.domain.comment.business.query;
+
+import com.midas.shootpointer.domain.comment.business.CommentManager;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CommentQueryServiceImpl implements CommentQueryService {
+	
+	private final CommentManager commentManager;
+	
+	@Override
+	@Transactional(readOnly = true)
+	public List<Comment> getCommentsByPostId(Long postId) {
+		return commentManager.findCommentByPostId(postId);
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentQueryController.java
@@ -1,0 +1,36 @@
+package com.midas.shootpointer.domain.comment.controller;
+
+import com.midas.shootpointer.domain.comment.business.query.CommentQueryService;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
+import com.midas.shootpointer.global.dto.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/comment")
+@RequiredArgsConstructor
+public class CommentQueryController {
+	
+	private final CommentQueryService commentQueryService;
+	private final CommentMapper commentMapper;
+	
+	@GetMapping("/{postId}")
+	public ResponseEntity<ApiResponse<List<CommentResponseDto>>>
+	getCommentsByPostId(@PathVariable Long postId) {
+		List<Comment> comments = commentQueryService.getCommentsByPostId(postId); // List로 댓글들 다 불러오기(최신순)
+		
+		List<CommentResponseDto> responseDto = comments.stream()
+			.map(commentMapper::entityToDto)
+			.toList();
+		
+		return ResponseEntity.ok(ApiResponse.ok(responseDto));
+	}
+	
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponse.java
@@ -1,4 +1,0 @@
-package com.midas.shootpointer.domain.comment.dto.response;
-
-public class CommentResponse {
-}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponseDto.java
@@ -19,7 +19,7 @@ public class CommentResponseDto {
 	
 	private String content;
 	
-	private String writerName;
+	private String memberName;
 	
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
 	private LocalDateTime createdAt;

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,26 @@
+package com.midas.shootpointer.domain.comment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class CommentResponseDto {
+	
+	private Long commentId;
+	
+	private String content;
+	
+	private String writerName;
+	
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -21,7 +22,9 @@ import org.hibernate.annotations.SQLRestriction;
 @Entity
 @RequiredArgsConstructor
 @AllArgsConstructor
-@Table(name = "comment")
+@Table(name = "comment",
+	indexes = {@Index(name = "idx_comment_post_created", columnList = "post_id, created_at DESC")}
+)
 @SQLRestriction("is_deleted = false")
 @Getter
 @Builder

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
@@ -1,5 +1,9 @@
 package com.midas.shootpointer.domain.comment.helper;
 
-public interface CommentHelper extends CommentValidation, CommentUtil {
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
 
+public interface CommentHelper extends CommentValidation, CommentUtil {
+	
+	List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.comment.helper;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -18,5 +19,10 @@ public class CommentHelperImpl implements CommentHelper {
 	@Override
 	public Comment save(Comment comment) {
 		return commentUtil.save(comment);
+	}
+	
+	@Override
+	public List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId) {
+		return commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
@@ -1,8 +1,11 @@
 package com.midas.shootpointer.domain.comment.helper;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
 
 public interface CommentUtil {
 	
 	Comment save(Comment comment);
+	
+	List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
@@ -2,6 +2,8 @@ package com.midas.shootpointer.domain.comment.helper;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.repository.command.CommentCommandRepository;
+import com.midas.shootpointer.domain.comment.repository.query.CommentQueryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,9 +12,15 @@ import org.springframework.stereotype.Component;
 public class CommentUtilImpl implements CommentUtil {
 	
 	private final CommentCommandRepository commentCommandRepository;
+	private final CommentQueryRepository commentQueryRepository;
 	
 	@Override
 	public Comment save(Comment comment) {
 		return commentCommandRepository.save(comment);
+	}
+	
+	@Override
+	public List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId) {
+		return commentQueryRepository.findAllByPostIdOrderByCreatedAtDesc(postId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapper.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.comment.mapper;
 
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
@@ -8,4 +9,6 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 public interface CommentMapper {
 	
 	Comment dtoToEntity(CommentRequestDto commentRequestDto, Member member, PostEntity post);
+	
+	CommentResponseDto entityToDto(Comment comment);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.comment.mapper;
 
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
@@ -16,6 +17,16 @@ public class CommentMapperImpl implements CommentMapper {
 			.content(commentRequestDto.getContent())
 			.member(member)
 			.post(post)
+			.build();
+	}
+	
+	@Override
+	public CommentResponseDto entityToDto(Comment comment) {
+		return CommentResponseDto.builder()
+			.commentId(comment.getCommentId())
+			.content(comment.getContent())
+			.writerName(comment.getMember().getUsername())
+			.createdAt(comment.getCreatedAt())
 			.build();
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImpl.java
@@ -25,7 +25,7 @@ public class CommentMapperImpl implements CommentMapper {
 		return CommentResponseDto.builder()
 			.commentId(comment.getCommentId())
 			.content(comment.getContent())
-			.writerName(comment.getMember().getUsername())
+			.memberName(comment.getMember().getUsername())
 			.createdAt(comment.getCreatedAt())
 			.build();
 	}

--- a/src/main/java/com/midas/shootpointer/domain/comment/repository/query/CommentQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/repository/query/CommentQueryRepository.java
@@ -1,0 +1,18 @@
+package com.midas.shootpointer.domain.comment.repository.query;
+
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentQueryRepository extends JpaRepository<Comment, Long> {
+	
+	@Query("SELECT c FROM Comment c " +
+		"JOIN FETCH c.member " +
+		"WHERE c.post.postId = :postId " +
+		"ORDER BY c.createdAt DESC")
+	List<Comment> findAllByPostIdOrderByCreatedAtDesc(@Param("postId") Long postId);
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -18,6 +18,8 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.Arrays;
+import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -119,11 +121,79 @@ class CommentManagerTest {
 			.isInstanceOf(NullPointerException.class);
 	}
 	
+	@Test
+	@DisplayName("게시물 ID로 댓글 목록 조회 성공")
+	void findCommentsByPostId_Success() {
+		// given
+		Long postId = 1L;
+		PostEntity post = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		List<Comment> comments = Arrays.asList(
+			createCommentWithId(1L, "첫 번째 댓글", post),
+			createCommentWithId(2L, "두 번째 댓글", post),
+			createCommentWithId(3L, "세 번째 댓글", post)
+		);
+		
+		given(postHelper.findPostByPostId(postId)).willReturn(post);
+		given(commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId)).willReturn(comments);
+		
+		// when
+		List<Comment> result = commentManager.findCommentsByPostId(postId);
+		
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result).isEqualTo(comments);
+		then(postHelper).should().findPostByPostId(postId);
+		then(commentHelper).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 성공 - 댓글이 없는 경우")
+	void findCommentsByPostId_Success_EmptyList() {
+		// given
+		Long postId = 1L;
+		PostEntity post = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		given(postHelper.findPostByPostId(postId)).willReturn(post);
+		given(commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId)).willReturn(List.of());
+		
+		// when
+		List<Comment> result = commentManager.findCommentsByPostId(postId);
+		
+		// then
+		assertThat(result).isEmpty();
+		then(postHelper).should().findPostByPostId(postId);
+		then(commentHelper).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 실패 - 존재하지 않는 게시물")
+	void findCommentsByPostId_Failed_PostNotFound() {
+		// given
+		Long postId = 999L;
+		
+		given(postHelper.findPostByPostId(postId)).willThrow(
+			new CustomException(ErrorCode.IS_NOT_EXIST_POST)
+		);
+		
+		// when-then
+		assertThatThrownBy(() -> commentManager.findCommentsByPostId(postId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
+		
+		then(postHelper).should().findPostByPostId(postId);
+		then(commentHelper).should(never()).findAllByPostIdOrderByCreatedAtDesc(anyLong());
+	}
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(java.util.UUID.randomUUID())
-			.email("test@test.com")
-			.username("testUser")
+			.email("test@naver.com")
+			.username("test")
 			.build();
 		
 		PostEntity post = PostEntity.builder()
@@ -137,11 +207,26 @@ class CommentManagerTest {
 			.build();
 	}
 	
+	private Comment createCommentWithId(Long commentId, String content, PostEntity post) {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		return Comment.builder()
+			.commentId(commentId)
+			.content(content)
+			.member(member)
+			.post(post)
+			.build();
+	}
+	
 	private Member createMember() {
 		return Member.builder()
 			.memberId(java.util.UUID.randomUUID())
-			.email("test@test.com")
-			.username("testUser")
+			.email("test@naver.com")
+			.username("test")
 			.build();
 	}
 }

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -54,7 +54,6 @@ class CommentManagerTest {
 			.build();
 		
 		given(postHelper.findPostByPostId(anyLong())).willReturn(comment.getPost());
-		willDoNothing().given(commentHelper).validatePostExists(anyLong());
 		given(commentHelper.save(any(Comment.class))).willReturn(savedComment);
 		
 		// when
@@ -63,7 +62,6 @@ class CommentManagerTest {
 		// then
 		assertThat(result).isEqualTo(1L);
 		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
-		then(commentHelper).should().validatePostExists(comment.getPost().getPostId());
 		then(commentHelper).should().save(comment);
 	}
 	
@@ -84,26 +82,6 @@ class CommentManagerTest {
 		
 		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
 		then(commentHelper).shouldHaveNoInteractions();
-	}
-	
-	@Test
-	@DisplayName("CommentHelper에서 게시물 검증 실패 -> 예외 발생")
-	void save_Validation_Post_ThrowException() {
-		// given
-		Comment comment = createComment();
-		
-		given(postHelper.findPostByPostId(anyLong())).willReturn(comment.getPost());
-		willThrow(new CustomException(ErrorCode.IS_NOT_EXIST_POST))
-			.given(commentHelper).validatePostExists(anyLong());
-		
-		// when-then
-		assertThatThrownBy(() -> commentManager.save(comment))
-			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
-		
-		then(postHelper).should().findPostByPostId(comment.getPost().getPostId());
-		then(commentHelper).should().validatePostExists(comment.getPost().getPostId());
-		then(commentHelper).should(never()).save(any(Comment.class));
 	}
 	
 	@Test

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/query/CommentQueryServiceImplTest.java
@@ -1,0 +1,110 @@
+package com.midas.shootpointer.domain.comment.business.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import com.midas.shootpointer.domain.comment.business.CommentManager;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CommentQueryServiceImpl 테스트")
+class CommentQueryServiceImplTest {
+	
+	@Mock
+	private CommentManager commentManager;
+	
+	@InjectMocks
+	private CommentQueryServiceImpl commentQueryService;
+	
+	@Test
+	@DisplayName("게시물 ID로 댓글 목록 조회_Success")
+	void getCommentsByPostId_Success() {
+		// given
+		Long postId = 1L;
+		PostEntity post = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		List<Comment> comments = Arrays.asList(
+			createCommentWithId(3L, "최신 댓글", post),
+			createCommentWithId(2L, "중간 댓글", post),
+			createCommentWithId(1L, "오래된 댓글", post)
+		);
+		
+		given(commentManager.findCommentsByPostId(postId)).willReturn(comments);
+		
+		// when
+		List<Comment> result = commentQueryService.getCommentsByPostId(postId);
+		
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getCommentId()).isEqualTo(3L);
+		assertThat(result.get(0).getContent()).isEqualTo("최신 댓글");
+		assertThat(result.get(1).getCommentId()).isEqualTo(2L);
+		assertThat(result.get(2).getCommentId()).isEqualTo(1L);
+		then(commentManager).should().findCommentsByPostId(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회_Success - 빈 리스트 반환")
+	void getCommentsByPostId_Success_EmptyList() {
+		// given
+		Long postId = 1L;
+		given(commentManager.findCommentsByPostId(postId)).willReturn(List.of());
+		
+		// when
+		List<Comment> result = commentQueryService.getCommentsByPostId(postId);
+		
+		// then
+		assertThat(result).isEmpty();
+		then(commentManager).should().findCommentsByPostId(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회_Failed - 존재하지 않는 게시물")
+	void getCommentsByPostId_Failed_PostNotFound() {
+		// given
+		Long postId = 999L;
+		given(commentManager.findCommentsByPostId(postId)).willThrow(
+			new CustomException(ErrorCode.IS_NOT_EXIST_POST)
+		);
+		
+		// when-then
+		assertThatThrownBy(() -> commentQueryService.getCommentsByPostId(postId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
+		
+		then(commentManager).should().findCommentsByPostId(postId);
+	}
+	
+	private Comment createCommentWithId(Long commentId, String content, PostEntity post) {
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		return Comment.builder()
+			.commentId(commentId)
+			.content(content)
+			.member(member)
+			.post(post)
+			.build();
+	}
+
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
@@ -216,7 +216,7 @@ class CommentQueryControllerTest {
 		return CommentResponseDto.builder()
 			.commentId(commentId)
 			.content(content)
-			.writerName(writerName)
+			.memberName(writerName)
 			.createdAt(LocalDateTime.now())
 			.build();
 	}

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
@@ -1,0 +1,223 @@
+package com.midas.shootpointer.domain.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.midas.shootpointer.domain.comment.business.query.CommentQueryService;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@DisplayName("CommentQueryController 테스트")
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class CommentQueryControllerTest {
+	
+	@Autowired
+	private MockMvc mockMvc;
+	
+	@Autowired
+	private ObjectMapper objectMapper;
+	
+	@MockitoBean
+	private CommentQueryService commentQueryService;
+	
+	@MockitoBean
+	private CommentMapper commentMapper;
+	
+	private final String baseUrl = "/api/comment/";
+	
+	@BeforeEach
+	void setUp() {
+		objectMapper = new ObjectMapper();
+	}
+	
+	@Test
+	@DisplayName("게시물 ID로 댓글 목록 조회 성공")
+	void getCommentsByPostId_Success() throws Exception {
+		// given
+		Long postId = 1L;
+		PostEntity post = createPostEntity(postId);
+		
+		List<Comment> comments = Arrays.asList(
+			createCommentWithId(3L, "최신 댓글", post),
+			createCommentWithId(2L, "중간 댓글", post),
+			createCommentWithId(1L, "오래된 댓글", post)
+		);
+		
+		List<CommentResponseDto> responseDtos = Arrays.asList(
+			createResponseDto(3L, "최신 댓글", "테스트유저1"),
+			createResponseDto(2L, "중간 댓글", "테스트유저2"),
+			createResponseDto(1L, "오래된 댓글", "테스트유저3")
+		);
+		
+		// when
+		when(commentQueryService.getCommentsByPostId(postId)).thenReturn(comments);
+		when(commentMapper.entityToDto(comments.get(0))).thenReturn(responseDtos.get(0));
+		when(commentMapper.entityToDto(comments.get(1))).thenReturn(responseDtos.get(1));
+		when(commentMapper.entityToDto(comments.get(2))).thenReturn(responseDtos.get(2));
+		
+		// then
+		mockMvc.perform(get(baseUrl + "/" + postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(3))
+			.andExpect(jsonPath("$.data[0].commentId").value(3L))
+			.andExpect(jsonPath("$.data[0].content").value("최신 댓글"))
+			.andExpect(jsonPath("$.data[0].writerName").value("테스트유저1"))
+			.andExpect(jsonPath("$.data[1].commentId").value(2L))
+			.andExpect(jsonPath("$.data[2].commentId").value(1L))
+			.andDo(print());
+		
+		verify(commentQueryService, times(1)).getCommentsByPostId(postId);
+		verify(commentMapper, times(3)).entityToDto(any(Comment.class));
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 성공 - 빈 리스트")
+	void getCommentsByPostId_Success_EmptyList() throws Exception {
+		// given
+		Long postId = 1L;
+		
+		// when
+		when(commentQueryService.getCommentsByPostId(postId)).thenReturn(List.of());
+		
+		// then
+		mockMvc.perform(get(baseUrl + "/" + postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(0))
+			.andDo(print());
+		
+		verify(commentQueryService, times(1)).getCommentsByPostId(postId);
+		verify(commentMapper, times(0)).entityToDto(any(Comment.class));
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 실패 - 존재하지 않는 게시물")
+	void getCommentsByPostId_Failed_PostNotFound() throws Exception {
+		// given
+		Long postId = 999L;
+		
+		// when
+		when(commentQueryService.getCommentsByPostId(postId))
+			.thenThrow(new CustomException(ErrorCode.IS_NOT_EXIST_POST));
+		
+		// then
+		mockMvc.perform(get(baseUrl + "/" + postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().is2xxSuccessful())
+			.andDo(print());
+		
+		verify(commentQueryService, times(1)).getCommentsByPostId(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 실패 - 잘못된 게시물 ID 형식")
+	void getCommentsByPostId_Failed_InvalidPostIdFormat() throws Exception {
+		// given
+		String invalidPostId = "invalid";
+		
+		// when-then
+		mockMvc.perform(get(baseUrl + "/" + invalidPostId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().is2xxSuccessful())
+			.andDo(print());
+	}
+	
+	@Test
+	@DisplayName("단일 댓글 조회 성공")
+	void getCommentsByPostId_Success_SingleComment() throws Exception {
+		// given
+		Long postId = 1L;
+		PostEntity post = createPostEntity(postId);
+		
+		List<Comment> comments = List.of(
+			createCommentWithId(1L, "단일 댓글입니다.", post)
+		);
+		
+		List<CommentResponseDto> responseDtos = List.of(
+			createResponseDto(1L, "단일 댓글입니다.", "test")
+		);
+		
+		// when
+		when(commentQueryService.getCommentsByPostId(postId)).thenReturn(comments);
+		when(commentMapper.entityToDto(comments.get(0))).thenReturn(responseDtos.get(0));
+		
+		// then
+		mockMvc.perform(get(baseUrl + "/" + postId)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.data[0].commentId").value(1L))
+			.andExpect(jsonPath("$.data[0].content").value("단일 댓글입니다."))
+			.andExpect(jsonPath("$.data[0].writerName").value("test"))
+			.andDo(print());
+		
+		verify(commentQueryService, times(1)).getCommentsByPostId(postId);
+		verify(commentMapper, times(1)).entityToDto(comments.get(0));
+	}
+	
+	private Member createMember() {
+		return Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+	}
+	
+	private PostEntity createPostEntity(Long postId) {
+		return PostEntity.builder()
+			.postId(postId)
+			.build();
+	}
+	
+	private Comment createCommentWithId(Long commentId, String content, PostEntity post) {
+		return Comment.builder()
+			.commentId(commentId)
+			.content(content)
+			.member(createMember())
+			.post(post)
+			.build();
+	}
+	
+	private CommentResponseDto createResponseDto(Long commentId, String content, String writerName) {
+		return CommentResponseDto.builder()
+			.commentId(commentId)
+			.content(content)
+			.writerName(writerName)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentQueryControllerTest.java
@@ -91,7 +91,7 @@ class CommentQueryControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(3))
 			.andExpect(jsonPath("$.data[0].commentId").value(3L))
 			.andExpect(jsonPath("$.data[0].content").value("최신 댓글"))
-			.andExpect(jsonPath("$.data[0].writerName").value("테스트유저1"))
+			.andExpect(jsonPath("$.data[0].memberName").value("테스트유저1"))
 			.andExpect(jsonPath("$.data[1].commentId").value(2L))
 			.andExpect(jsonPath("$.data[2].commentId").value(1L))
 			.andDo(print());
@@ -182,7 +182,7 @@ class CommentQueryControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(1))
 			.andExpect(jsonPath("$.data[0].commentId").value(1L))
 			.andExpect(jsonPath("$.data[0].content").value("단일 댓글입니다."))
-			.andExpect(jsonPath("$.data[0].writerName").value("test"))
+			.andExpect(jsonPath("$.data[0].memberName").value("test"))
 			.andDo(print());
 		
 		verify(commentQueryService, times(1)).getCommentsByPostId(postId);

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
@@ -14,6 +14,8 @@ import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,6 +87,49 @@ class CommentHelperImplTest {
 		then(commentUtil).should().save(comment);
 	}
 	
+	@Test
+	@DisplayName("게시물 ID로 댓글 목록 조회 성공")
+	void findAllByPostIdOrderByCreatedAtDesc_Success() {
+		// given
+		Long postId = 1L;
+		PostEntity post = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		List<Comment> comments = Arrays.asList(
+			createCommentWithId(3L, "최신 댓글", post),
+			createCommentWithId(2L, "중간 댓글", post),
+			createCommentWithId(1L, "오래된 댓글", post)
+		);
+		
+		given(commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId)).willReturn(comments);
+		
+		// when
+		List<Comment> result = commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId);
+		
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getCommentId()).isEqualTo(3L);
+		assertThat(result.get(1).getCommentId()).isEqualTo(2L);
+		assertThat(result.get(2).getCommentId()).isEqualTo(1L);
+		then(commentUtil).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 성공 - 빈 리스트 반환")
+	void findAllByPostIdOrderByCreatedAtDesc_Success_EmptyList() {
+		// given
+		Long postId = 1L;
+		given(commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId)).willReturn(List.of());
+		
+		// when
+		List<Comment> result = commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId);
+		
+		// then
+		assertThat(result).isEmpty();
+		then(commentUtil).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(java.util.UUID.randomUUID())
@@ -98,6 +143,21 @@ class CommentHelperImplTest {
 		
 		return Comment.builder()
 			.content("테스트입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+	
+	private Comment createCommentWithId(Long commentId, String content, PostEntity post) {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		return Comment.builder()
+			.commentId(commentId)
+			.content(content)
 			.member(member)
 			.post(post)
 			.build();

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
@@ -8,8 +8,11 @@ import static org.mockito.BDDMockito.willThrow;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.repository.command.CommentCommandRepository;
+import com.midas.shootpointer.domain.comment.repository.query.CommentQueryRepository;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +27,9 @@ class CommentUtilImplTest {
 	
 	@Mock
 	private CommentCommandRepository commentCommandRepository;
+	
+	@Mock
+	private CommentQueryRepository commentQueryRepository;
 	
 	@InjectMocks
 	private CommentUtilImpl commentUtil;
@@ -52,11 +58,57 @@ class CommentUtilImplTest {
 		then(commentCommandRepository).should().save(comment);
 	}
 	
+	@Test
+	@DisplayName("게시물 ID로 댓글 목록 조회 성공 - 최신순 정렬")
+	void findAllByPostIdOrderByCreatedAtDesc_Success() {
+		// given
+		Long postId = 1L;
+		PostEntity post = PostEntity.builder()
+			.postId(postId)
+			.build();
+		
+		List<Comment> comments = Arrays.asList(
+			createCommentWithId(3L, "최신 댓글", post),
+			createCommentWithId(2L, "중간 댓글", post),
+			createCommentWithId(1L, "오래된 댓글", post)
+		);
+		
+		given(commentQueryRepository.findAllByPostIdOrderByCreatedAtDesc(postId))
+			.willReturn(comments);
+		
+		// when
+		List<Comment> result = commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId);
+		
+		// then
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getCommentId()).isEqualTo(3L);
+		assertThat(result.get(0).getContent()).isEqualTo("최신 댓글");
+		assertThat(result.get(1).getCommentId()).isEqualTo(2L);
+		assertThat(result.get(2).getCommentId()).isEqualTo(1L);
+		then(commentQueryRepository).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
+	@Test
+	@DisplayName("댓글 목록 조회 성공 - 빈 리스트")
+	void findAllByPostIdOrderByCreatedAtDesc_Success_EmptyList() {
+		// given
+		Long postId = 999L;
+		given(commentQueryRepository.findAllByPostIdOrderByCreatedAtDesc(postId))
+			.willReturn(List.of());
+		
+		// when
+		List<Comment> result = commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId);
+		
+		// then
+		assertThat(result).isEmpty();
+		then(commentQueryRepository).should().findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(java.util.UUID.randomUUID())
-			.email("test@test.com")
-			.username("testUser")
+			.email("test@naver.com")
+			.username("test")
 			.build();
 		
 		PostEntity post = PostEntity.builder()
@@ -65,6 +117,21 @@ class CommentUtilImplTest {
 		
 		return Comment.builder()
 			.content("테스트 댓글입니다.")
+			.member(member)
+			.post(post)
+			.build();
+	}
+	
+	private Comment createCommentWithId(Long commentId, String content, PostEntity post) {
+		Member member = Member.builder()
+			.memberId(java.util.UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		return Comment.builder()
+			.commentId(commentId)
+			.content(content)
 			.member(member)
 			.post(post)
 			.build();

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
@@ -120,5 +121,63 @@ class CommentMapperImplTest {
 		assertThat(result.getContent()).isEqualTo(requestDto.getContent());
 		assertThat(result.getMember()).isEqualTo(member);
 		assertThat(result.getPost()).isNull();
+	}
+	
+	@Test
+	@DisplayName("Entity -> DTO 변환 성공")
+	void entityToDto_Success() {
+		// given
+		Member member = Member.builder()
+			.memberId(UUID.randomUUID())
+			.email("test@naver.com")
+			.username("test")
+			.build();
+		
+		PostEntity post = PostEntity.builder()
+			.postId(1L)
+			.build();
+		
+		Comment comment = Comment.builder()
+			.commentId(1L)
+			.content("테스트 댓글입니다.")
+			.member(member)
+			.post(post)
+			.build();
+		
+		// when
+		CommentResponseDto result = commentMapper.entityToDto(comment);
+		
+		// then
+		assertThat(result).isNotNull();
+		assertThat(result.getCommentId()).isEqualTo(1L);
+		assertThat(result.getContent()).isEqualTo("테스트 댓글입니다.");
+		assertThat(result.getWriterName()).isEqualTo("test");
+	}
+	
+	@Test
+	@DisplayName("Entity -> DTO 변환 실패 - Comment가 Null인 경우")
+	void entityToDto_Failed_NullComment() {
+		// given
+		Comment comment = null;
+		
+		// when-then
+		assertThatThrownBy(() -> commentMapper.entityToDto(comment))
+			.isInstanceOf(NullPointerException.class);
+	}
+	
+	@Test
+	@DisplayName("Entity -> DTO 변환 실패 - Member가 Null인 경우")
+	void entityToDto_Failed_NullMember() {
+		// given
+		Comment comment = Comment.builder()
+			.commentId(1L)
+			.content("테스트 댓글")
+			.member(null)
+			.post(PostEntity.builder().postId(1L).build())
+			.build();
+		
+		// when-then
+		assertThatThrownBy(() -> commentMapper.entityToDto(comment))
+			.isInstanceOf(NullPointerException.class);
 	}
 }

--- a/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/mapper/CommentMapperImplTest.java
@@ -1,7 +1,6 @@
 package com.midas.shootpointer.domain.comment.mapper;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
 import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
@@ -9,7 +8,6 @@ import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -151,7 +149,7 @@ class CommentMapperImplTest {
 		assertThat(result).isNotNull();
 		assertThat(result.getCommentId()).isEqualTo(1L);
 		assertThat(result.getContent()).isEqualTo("테스트 댓글입니다.");
-		assertThat(result.getWriterName()).isEqualTo("test");
+		assertThat(result.getMemberName()).isEqualTo("test");
 	}
 	
 	@Test


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #121 

---

## ✅ 작업 사항

➡️ `게시물 ID`에 해당하는 댓글을 모두 조회하여 **DTO**로 반환하는 작업을 진행하였습니다.

➡️ 최신순 정렬: **ORDER BY createdAt DESC**

➡️ N+1 문제 해결: `JOIN FETCH`로 작성자 정보 **즉시 로딩**

➡️ 게시물 존재 여부 검증: 조회 전 `PostHelper`로 검증

---
 
#### ❓왜 JOIN FETCH를 사용했나요?
N+1 문제를 방지하기 위해서입니다.
JOIN FETCH를 사용하지 않으면 댓글 목록을 조회하는 쿼리 1번 실행 / 각 댓글마다 작성자(Member) 정보를 조회하는 쿼리 N번 실행

**총 N + 1번의 쿼리가 실행됨**

**JOIN FETCH**를 사용하면 댓글과 작성자 정보를 한 번에 조회하는 쿼리 1번만 실행
Member가 `@ManyToOne(fetch = FetchType.LAZY)`로 **지연 로딩**이지만, **JOIN FETCH로 즉시 로딩 처리**

특히
 ```java
.writerName(comment.getMember().getUsername())
```
이렇게 `comment.getMember()`를 호출할 때, **JOIN FETCH**가 없으면 각 댓글마다 추가 쿼리가 발생합니다.

댓글이 100개면 101번의 쿼리 → 1번의 쿼리로 최적화 가능한 코드를 구현하였습니다.

---

## ⌨ 기타

현재 **CommentManager** 클래스에서 **Validation** 검증 로직에 대한 의견 및 피드백을 듣고 싶습니다.
**TODO**로 체크해 두었긴 한데, 현재 save 메서드 내에서
```java
// 1
postHelper.findPostByPostId(comment.getPost().getPostId());
```

``` java
// 2
commentHelper.validatePostExists(comment.getPost().getPostId());
```
1번 메서드와 2번 메서드가 사실상 같은 역할을 하지만 다른 코드로 구현되어 있어 검증을 2번 하게 되는 셈인데,,, 도메인 분리를 위해 따로 구현할 것인지(위 코드에서는 1번을 날리고 2번을 사용) 아니면 postHelper의 게시물 찾기 로직과 commentHelper의 게시물 찾기 로직을 하나로 통합할 것인지 @tkv00 님의 의견도 궁금합니다🔥
