### PR TITLE
🌟 Feature : 댓글 삭제 작업[ D ] 및 테스트 코드 작업

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -4,6 +4,7 @@ import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.helper.CommentHelper;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,5 +28,12 @@ public class CommentManager {
 		postHelper.findPostByPostId(postId);
 		
 		return commentHelper.findAllByPostIdOrderByCreatedAtDesc(postId); // 최신순으로 댓글을 모두 조회
+	}
+	
+	@Transactional
+	public void delete(Long commentId, UUID memberId) {
+		Comment comment = commentHelper.findCommentByCommentId(commentId);
+		commentHelper.validateCommentOwner(comment, memberId);
+		commentHelper.delete(comment);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
@@ -1,8 +1,11 @@
 package com.midas.shootpointer.domain.comment.business.command;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.UUID;
 
 public interface CommentCommandService {
 	
 	Long create(Comment comment);
+	
+	void delete(Long commentId, UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.comment.business.command;
 
 import com.midas.shootpointer.domain.comment.business.CommentManager;
 import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,4 +19,9 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 		return commentManager.save(comment);
 	}
 	
+	@Override
+	@Transactional
+	public void delete(Long commentId, UUID memberId) {
+		commentManager.delete(commentId, memberId);
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -11,6 +11,8 @@ import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,5 +37,13 @@ public class CommentCommandController {
 		
 		return ResponseEntity.ok(ApiResponse.created(commentCommandService.create(comment)));
 	}
-
+	
+	@DeleteMapping("/{commentId}")
+	public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long commentId) {
+		
+		Member member = SecurityUtils.getCurrentMember();
+		commentCommandService.delete(commentId, member.getMemberId());
+		
+		return ResponseEntity.ok(ApiResponse.ok(null));
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -44,6 +44,6 @@ public class CommentCommandController {
 		Member member = SecurityUtils.getCurrentMember();
 		commentCommandService.delete(commentId, member.getMemberId());
 		
-		return ResponseEntity.ok(ApiResponse.ok(null));
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
@@ -2,8 +2,16 @@ package com.midas.shootpointer.domain.comment.helper;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import java.util.List;
+import java.util.UUID;
 
 public interface CommentHelper extends CommentValidation, CommentUtil {
 	
 	List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId);
+	
+	Comment findCommentByCommentId(Long commentId);
+	
+	void delete(Comment comment);
+	
+	void validateCommentOwner(Comment comment, UUID memberId);
+	
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.comment.helper;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -24,5 +25,20 @@ public class CommentHelperImpl implements CommentHelper {
 	@Override
 	public List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId) {
 		return commentUtil.findAllByPostIdOrderByCreatedAtDesc(postId);
+	}
+	
+	@Override
+	public Comment findCommentByCommentId(Long commentId) {
+		return commentUtil.findCommentByCommentId(commentId);
+	}
+	
+	@Override
+	public void delete(Comment comment) {
+		commentUtil.delete(comment);
+	}
+	
+	@Override
+	public void validateCommentOwner(Comment comment, UUID memberId) {
+		commentValidation.validateCommentOwner(comment, memberId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
@@ -8,4 +8,8 @@ public interface CommentUtil {
 	Comment save(Comment comment);
 	
 	List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId);
+	
+	Comment findCommentByCommentId(Long commentId);
+	
+	void delete(Comment comment);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
@@ -3,6 +3,8 @@ package com.midas.shootpointer.domain.comment.helper;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.repository.command.CommentCommandRepository;
 import com.midas.shootpointer.domain.comment.repository.query.CommentQueryRepository;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -23,4 +25,18 @@ public class CommentUtilImpl implements CommentUtil {
 	public List<Comment> findAllByPostIdOrderByCreatedAtDesc(Long postId) {
 		return commentQueryRepository.findAllByPostIdOrderByCreatedAtDesc(postId);
 	}
+	
+	@Override
+	public Comment findCommentByCommentId(Long commentId) {
+		return commentQueryRepository.findCommentByCommentId(commentId)
+			.orElseThrow(() -> new CustomException(ErrorCode.IS_NOT_EXIST_COMMENT));
+	}
+	
+	@Override
+	public void delete(Comment comment) {
+		comment.delete();
+		commentCommandRepository.save(comment);
+	}
+	
+	
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
@@ -1,6 +1,11 @@
 package com.midas.shootpointer.domain.comment.helper;
 
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import java.util.UUID;
+
 public interface CommentValidation {
 	
 	void validatePostExists(Long postId);
+	
+	void validateCommentOwner(Comment comment, UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
@@ -1,8 +1,10 @@
 package com.midas.shootpointer.domain.comment.helper;
 
+import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,4 +22,12 @@ public class CommentValidationImpl implements CommentValidation {
 			throw new CustomException(ErrorCode.IS_NOT_EXIST_POST);
 		}
 	}
+	
+	@Override
+	public void validateCommentOwner(Comment comment, UUID memberId) {
+		if (!comment.getMember().getMemberId().equals(memberId)) { // 댓글 작성자가 실제 로그인한 사용자가 아닌 경우
+			throw new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE);
+		}
+	}
+	
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/repository/query/CommentQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/repository/query/CommentQueryRepository.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.comment.repository.query;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +16,6 @@ public interface CommentQueryRepository extends JpaRepository<Comment, Long> {
 		"WHERE c.post.postId = :postId " +
 		"ORDER BY c.createdAt DESC")
 	List<Comment> findAllByPostIdOrderByCreatedAtDesc(@Param("postId") Long postId);
+	
+	Optional<Comment> findCommentByCommentId(Long commentId);
 }

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -105,9 +105,10 @@ public enum ErrorCode {
 
     //607(post-business) part
     IS_NOT_EXIST_POST(60701,HttpStatus.FORBIDDEN,"존재하지 않는 게시물입니다."),
-
+    
     // 806(comment - helper) part
-    INVALID_COMMENT_CONTENT(80601, HttpStatus.BAD_REQUEST, "유효하지 않은 댓글 내용입니다.");
+    IS_NOT_EXIST_COMMENT(80601, HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+    FORBIDDEN_COMMENT_DELETE(80602, HttpStatus.FORBIDDEN, "댓글 삭제 권한이 없습니다.");
 
 
     private final Integer code;

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
 
 import com.midas.shootpointer.domain.comment.business.CommentManager;
 import com.midas.shootpointer.domain.comment.entity.Comment;
@@ -18,10 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CommentCommandService 테스트")
@@ -48,6 +46,46 @@ class CommentCommandServiceImplTest {
 		// then
 		assertThat(result).isEqualTo(expectedCommentId);
 		then(commentManager).should().save(comment);
+	}
+	
+	@Test
+	@DisplayName("댓글 삭제 성공")
+	void delete_Success() {
+		// given
+		Long commentId = 1L;
+		UUID memberId = UUID.randomUUID();
+		
+		willDoNothing().given(commentManager).delete(commentId, memberId);
+		
+		// when
+		commentCommandService.delete(commentId, memberId);
+		
+		// then
+		then(commentManager).should(times(1)).delete(commentId, memberId);
+	}
+	
+	@Test
+	@DisplayName("여러 댓글 삭제 성공")
+	void delete_Multiple_Success() {
+		// given
+		UUID memberId = UUID.randomUUID();
+		Long commentId1 = 1L;
+		Long commentId2 = 2L;
+		Long commentId3 = 3L;
+		
+		willDoNothing().given(commentManager).delete(commentId1, memberId);
+		willDoNothing().given(commentManager).delete(commentId2, memberId);
+		willDoNothing().given(commentManager).delete(commentId3, memberId);
+		
+		// when
+		commentCommandService.delete(commentId1, memberId);
+		commentCommandService.delete(commentId2, memberId);
+		commentCommandService.delete(commentId3, memberId);
+		
+		// then
+		then(commentManager).should(times(1)).delete(commentId1, memberId);
+		then(commentManager).should(times(1)).delete(commentId2, memberId);
+		then(commentManager).should(times(1)).delete(commentId3, memberId);
 	}
 	
 	private Comment createComment() {

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
@@ -171,7 +171,7 @@ class CommentCommandControllerTest {
 		
 		// when-then
 		mockMvc.perform(delete(baseUrl + "/" + commentId))
-			.andExpect(status().isOk())
+			.andExpect(status().isNoContent())
 			.andExpect(jsonPath("$.success").value(true))
 			.andDo(print());
 	}
@@ -227,15 +227,15 @@ class CommentCommandControllerTest {
 		
 		// when-then
 		mockMvc.perform(delete(baseUrl + "/" + commentId1))
-			.andExpect(status().isOk())
+			.andExpect(status().isNoContent())
 			.andDo(print());
 		
 		mockMvc.perform(delete(baseUrl + "/" + commentId2))
-			.andExpect(status().isOk())
+			.andExpect(status().isNoContent())
 			.andDo(print());
 		
 		mockMvc.perform(delete(baseUrl + "/" + commentId3))
-			.andExpect(status().isOk())
+			.andExpect(status().isNoContent())
 			.andDo(print());
 		
 		verify(commentCommandService, times(1)).delete(eq(commentId1), any(UUID.class));

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
@@ -172,7 +172,6 @@ class CommentCommandControllerTest {
 		// when-then
 		mockMvc.perform(delete(baseUrl + "/" + commentId))
 			.andExpect(status().isNoContent())
-			.andExpect(jsonPath("$.success").value(true))
 			.andDo(print());
 	}
 	

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
@@ -2,9 +2,13 @@ package com.midas.shootpointer.domain.comment.controller;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -21,6 +25,7 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -152,6 +157,90 @@ class CommentCommandControllerTest {
 				.content(objectMapper.writeValueAsString(requestDto)))
 			.andExpect(status().is2xxSuccessful())
 			.andDo(print());
+	}
+	
+	
+	@Test
+	@DisplayName("댓글 삭제 성공")
+	@WithMockCustomMember
+	void delete_Success() throws Exception {
+		// given
+		Long commentId = 1L;
+		
+		willDoNothing().given(commentCommandService).delete(commentId, UUID.fromString("00000000-0000-0000-0000-000000000000"));
+		
+		// when-then
+		mockMvc.perform(delete(baseUrl + "/" + commentId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andDo(print());
+	}
+	
+	@Test
+	@DisplayName("댓글 삭제 실패 - 존재하지 않는 댓글")
+	@WithMockCustomMember
+	void delete_Failed_CommentNotFound() throws Exception {
+		// given
+		Long commentId = 999L;
+		
+		willThrow(new CustomException(ErrorCode.IS_NOT_EXIST_COMMENT))
+			.given(commentCommandService).delete(eq(commentId), any(UUID.class));
+		
+		// when-then
+		mockMvc.perform(delete(baseUrl + "/" + commentId))
+			.andExpect(status().is2xxSuccessful())
+			.andDo(print());
+		
+		verify(commentCommandService, times(1)).delete(eq(commentId), any(UUID.class));
+	}
+	
+	@Test
+	@DisplayName("댓글 삭제 실패 - 권한 없음 (작성자가 아님)")
+	@WithMockCustomMember
+	void delete_Failed_Forbidden() throws Exception {
+		// given
+		Long commentId = 1L;
+		
+		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE))
+			.given(commentCommandService).delete(eq(commentId), any(UUID.class));
+		
+		// when-then
+		mockMvc.perform(delete(baseUrl + "/" + commentId))
+			.andExpect(status().is2xxSuccessful())
+			.andDo(print());
+		
+		verify(commentCommandService, times(1)).delete(eq(commentId), any(UUID.class));
+	}
+	
+	@Test
+	@DisplayName("여러 댓글 순차적 삭제 성공")
+	@WithMockCustomMember
+	void delete_Multiple_Success() throws Exception {
+		// given
+		Long commentId1 = 1L;
+		Long commentId2 = 2L;
+		Long commentId3 = 3L;
+		
+		willDoNothing().given(commentCommandService).delete(eq(commentId1), any(UUID.class));
+		willDoNothing().given(commentCommandService).delete(eq(commentId2), any(UUID.class));
+		willDoNothing().given(commentCommandService).delete(eq(commentId3), any(UUID.class));
+		
+		// when-then
+		mockMvc.perform(delete(baseUrl + "/" + commentId1))
+			.andExpect(status().isOk())
+			.andDo(print());
+		
+		mockMvc.perform(delete(baseUrl + "/" + commentId2))
+			.andExpect(status().isOk())
+			.andDo(print());
+		
+		mockMvc.perform(delete(baseUrl + "/" + commentId3))
+			.andExpect(status().isOk())
+			.andDo(print());
+		
+		verify(commentCommandService, times(1)).delete(eq(commentId1), any(UUID.class));
+		verify(commentCommandService, times(1)).delete(eq(commentId2), any(UUID.class));
+		verify(commentCommandService, times(1)).delete(eq(commentId3), any(UUID.class));
 	}
 	
 	private Member createMember() {

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
+import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,4 +74,44 @@ class CommentValidationImplTest {
 			.isInstanceOf(CustomException.class)
 			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.IS_NOT_EXIST_POST);
 	}
+	
+	@Test
+	@DisplayName("댓글 작성자 검증 성공 - 동일한 작성자")
+	void validateCommentOwner_Success() {
+		// given
+		UUID memberId = UUID.randomUUID();
+		Member member = Member.builder()
+			.memberId(memberId)
+			.build();
+		
+		Comment comment = Comment.builder()
+			.member(member)
+			.build();
+		
+		// when-then
+		assertThatNoException().isThrownBy(() ->
+			commentValidation.validateCommentOwner(comment, memberId));
+	}
+	
+	@Test
+	@DisplayName("댓글 작성자 검증 실패 - 다른 작성자")
+	void validateCommentOwner_Failed_Forbidden() {
+		// given
+		UUID commentOwnerId = UUID.randomUUID();
+		UUID InvalidOwnerId = UUID.randomUUID(); // 다른 UUID
+		
+		Member member = Member.builder()
+			.memberId(commentOwnerId)
+			.build();
+		
+		Comment comment = Comment.builder()
+			.member(member)
+			.build();
+		
+		// when-then
+		assertThatThrownBy(() -> commentValidation.validateCommentOwner(comment, InvalidOwnerId))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_DELETE);
+	}
+	
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #123 

---

## ✅ 작업 사항

➡️ 댓글을 작성한 사용자만이 댓글을 삭제할 수 있도록 권한에 따른 로직 처리를 진행하였습니다.

➡️ 권한의 기준은 `commentId`, `memberId` 기준입니다.


기존 **[ C , R ]** 작업보다는 단순 DB에서 검증 및 삭제하는 로직만 진행하면 되므로 비교적 간단하게 구현했습니다.

---

## ⌨ 기타
