### PR TITLE
🌟 Feature : 댓글 수정 작업[ U ] 및 테스트 코드 작업

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -36,4 +36,12 @@ public class CommentManager {
 		commentHelper.validateCommentOwner(comment, memberId);
 		commentHelper.delete(comment);
 	}
+	
+	@Transactional
+	public void update(Long commentId, String content, UUID memberId) {
+		Comment comment = commentHelper.findCommentByCommentId(commentId); // 댓글이 있는지 확인하고
+		commentHelper.validateCommentOwner(comment, memberId); // 해당 댓글을 소유한 사용자인지 확인하고
+		commentHelper.validateContentNotBlank(content); // 빈 수정 내용이 아닌지 확인하고
+		commentHelper.updateContent(comment, content); // 댓글 내용 업데이트 작업
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/CommentManager.java
@@ -38,10 +38,11 @@ public class CommentManager {
 	}
 	
 	@Transactional
-	public void update(Long commentId, String content, UUID memberId) {
-		Comment comment = commentHelper.findCommentByCommentId(commentId); // 댓글이 있는지 확인하고
-		commentHelper.validateCommentOwner(comment, memberId); // 해당 댓글을 소유한 사용자인지 확인하고
-		commentHelper.validateContentNotBlank(content); // 빈 수정 내용이 아닌지 확인하고
-		commentHelper.updateContent(comment, content); // 댓글 내용 업데이트 작업
+	public Comment update(Long commentId, String content, UUID memberId) {
+		Comment comment = commentHelper.findCommentByCommentId(commentId);
+		commentHelper.validateCommentOwner(comment, memberId);
+		commentHelper.validateContentNotBlank(content);
+		commentHelper.updateContent(comment, content);
+		return comment;
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
@@ -8,4 +8,6 @@ public interface CommentCommandService {
 	Long create(Comment comment);
 	
 	void delete(Long commentId, UUID memberId);
+	
+	void update(Long commentId, String content, UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandService.java
@@ -9,5 +9,5 @@ public interface CommentCommandService {
 	
 	void delete(Long commentId, UUID memberId);
 	
-	void update(Long commentId, String content, UUID memberId);
+	Comment update(Long commentId, String content, UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.comment.business.command;
 
 import com.midas.shootpointer.domain.comment.business.CommentManager;
 import com.midas.shootpointer.domain.comment.entity.Comment;
+import com.midas.shootpointer.domain.comment.helper.CommentHelper;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 	}
 	
 	@Override
-	public void update(Long commentId, String content, UUID memberId) {
-		commentManager.update(commentId, content, memberId);
+	public Comment update(Long commentId, String content, UUID memberId) {
+		return commentManager.update(commentId, content, memberId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImpl.java
@@ -9,19 +9,23 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CommentCommandServiceImpl implements CommentCommandService {
 	
 	private final CommentManager commentManager;
 	
 	@Override
-	@Transactional
 	public Long create(Comment comment) {
 		return commentManager.save(comment);
 	}
 	
 	@Override
-	@Transactional
 	public void delete(Long commentId, UUID memberId) {
 		commentManager.delete(commentId, memberId);
+	}
+	
+	@Override
+	public void update(Long commentId, String content, UUID memberId) {
+		commentManager.update(commentId, content, memberId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.comment.controller;
 
 import com.midas.shootpointer.domain.comment.business.command.CommentCommandService;
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
+import com.midas.shootpointer.domain.comment.dto.request.CommentUpdateRequestDto;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
 import com.midas.shootpointer.domain.member.entity.Member;
@@ -9,9 +10,11 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.PostHelper;
 import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.SecurityUtils;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -45,5 +48,16 @@ public class CommentCommandController {
 		commentCommandService.delete(commentId, member.getMemberId());
 		
 		return ResponseEntity.noContent().build();
+	}
+	
+	@PatchMapping("/{commentId}")
+	public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long commentId,
+		@Valid @RequestBody CommentUpdateRequestDto updateRequestDto) {
+		
+		Member member = SecurityUtils.getCurrentMember();
+		commentCommandService.update(commentId, updateRequestDto.getContent(),
+			member.getMemberId());
+		
+		return ResponseEntity.ok(ApiResponse.okWithOutData());
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/controller/CommentCommandController.java
@@ -3,6 +3,7 @@ package com.midas.shootpointer.domain.comment.controller;
 import com.midas.shootpointer.domain.comment.business.command.CommentCommandService;
 import com.midas.shootpointer.domain.comment.dto.request.CommentRequestDto;
 import com.midas.shootpointer.domain.comment.dto.request.CommentUpdateRequestDto;
+import com.midas.shootpointer.domain.comment.dto.response.CommentResponseDto;
 import com.midas.shootpointer.domain.comment.entity.Comment;
 import com.midas.shootpointer.domain.comment.mapper.CommentMapper;
 import com.midas.shootpointer.domain.member.entity.Member;
@@ -51,13 +52,15 @@ public class CommentCommandController {
 	}
 	
 	@PatchMapping("/{commentId}")
-	public ResponseEntity<ApiResponse<Void>> update(@PathVariable Long commentId,
+	public ResponseEntity<ApiResponse<CommentResponseDto>> update(@PathVariable Long commentId,
 		@Valid @RequestBody CommentUpdateRequestDto updateRequestDto) {
 		
 		Member member = SecurityUtils.getCurrentMember();
-		commentCommandService.update(commentId, updateRequestDto.getContent(),
+		Comment updatedComment = commentCommandService.update(commentId, updateRequestDto.getContent(),
 			member.getMemberId());
 		
-		return ResponseEntity.ok(ApiResponse.okWithOutData());
+		CommentResponseDto responseDto = commentMapper.entityToDto(updatedComment);
+		
+		return ResponseEntity.ok(ApiResponse.ok(responseDto));
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentUpdateRequestDto.java
@@ -1,0 +1,17 @@
+package com.midas.shootpointer.domain.comment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentUpdateRequestDto {
+	
+	@NotBlank(message = "댓글 내용은 공백이 허용되지 않습니다.")
+	private String content;
+}

--- a/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/dto/request/CommentUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.comment.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class CommentUpdateRequestDto {
 	
 	@NotBlank(message = "댓글 내용은 공백이 허용되지 않습니다.")
+	@Max(value = 500, message = "댓글은 1자 이상 500자 이하로 작성해주세요.")
 	private String content;
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/entity/Comment.java
@@ -45,4 +45,7 @@ public class Comment extends BaseEntity {
 	@JoinColumn(name = "post_id", nullable = false)
 	private PostEntity post;
 	
+	public void updateContent(String content) {
+		this.content = content;
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
@@ -14,7 +14,7 @@ public interface CommentHelper extends CommentValidation, CommentUtil {
 	
 	void validateCommentOwner(Comment comment, UUID memberId);
 	
-	void updateContent(Comment comment, String content);
+	Comment updateContent(Comment comment, String content);
 	
 	void validateContentNotBlank(String content);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelper.java
@@ -14,4 +14,7 @@ public interface CommentHelper extends CommentValidation, CommentUtil {
 	
 	void validateCommentOwner(Comment comment, UUID memberId);
 	
+	void updateContent(Comment comment, String content);
+	
+	void validateContentNotBlank(String content);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -43,8 +43,8 @@ public class CommentHelperImpl implements CommentHelper {
 	}
 	
 	@Override
-	public void updateContent(Comment comment, String content) {
-		commentUtil.updateContent(comment, content);
+	public Comment updateContent(Comment comment, String content) {
+		return commentUtil.updateContent(comment, content);
 	}
 	
 	@Override

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImpl.java
@@ -41,4 +41,14 @@ public class CommentHelperImpl implements CommentHelper {
 	public void validateCommentOwner(Comment comment, UUID memberId) {
 		commentValidation.validateCommentOwner(comment, memberId);
 	}
+	
+	@Override
+	public void updateContent(Comment comment, String content) {
+		commentUtil.updateContent(comment, content);
+	}
+	
+	@Override
+	public void validateContentNotBlank(String content) {
+		commentValidation.validateContentNotBlank(content);
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
@@ -12,4 +12,6 @@ public interface CommentUtil {
 	Comment findCommentByCommentId(Long commentId);
 	
 	void delete(Comment comment);
+	
+	void updateContent(Comment comment, String content);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtil.java
@@ -13,5 +13,5 @@ public interface CommentUtil {
 	
 	void delete(Comment comment);
 	
-	void updateContent(Comment comment, String content);
+	Comment updateContent(Comment comment, String content);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
@@ -38,5 +38,11 @@ public class CommentUtilImpl implements CommentUtil {
 		commentCommandRepository.save(comment);
 	}
 	
+	@Override
+	public void updateContent(Comment comment, String content) {
+		comment.updateContent(content);
+		commentCommandRepository.save(comment);
+	}
+	
 	
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImpl.java
@@ -39,9 +39,9 @@ public class CommentUtilImpl implements CommentUtil {
 	}
 	
 	@Override
-	public void updateContent(Comment comment, String content) {
+	public Comment updateContent(Comment comment, String content) {
 		comment.updateContent(content);
-		commentCommandRepository.save(comment);
+		return commentCommandRepository.save(comment);
 	}
 	
 	

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidation.java
@@ -8,4 +8,6 @@ public interface CommentValidation {
 	void validatePostExists(Long postId);
 	
 	void validateCommentOwner(Comment comment, UUID memberId);
+	
+	void validateContentNotBlank(String content);
 }

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
@@ -26,7 +26,7 @@ public class CommentValidationImpl implements CommentValidation {
 	@Override
 	public void validateCommentOwner(Comment comment, UUID memberId) {
 		if (!comment.getMember().getMemberId().equals(memberId)) { // 댓글 작성자가 실제 로그인한 사용자가 아닌 경우
-			throw new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE);
+			throw new CustomException(ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 		}
 	}
 	

--- a/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImpl.java
@@ -30,4 +30,11 @@ public class CommentValidationImpl implements CommentValidation {
 		}
 	}
 	
+	@Override
+	public void validateContentNotBlank(String content) {
+		if (content == null || content.trim().isEmpty()) {
+			throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
+		}
+	}
+	
 }

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -108,7 +108,8 @@ public enum ErrorCode {
     
     // 806(comment - helper) part
     IS_NOT_EXIST_COMMENT(80601, HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-    FORBIDDEN_COMMENT_ACCESS(80602, HttpStatus.FORBIDDEN, "댓글 접근 권한이 없습니다.");
+    FORBIDDEN_COMMENT_ACCESS(80602, HttpStatus.FORBIDDEN, "댓글 접근 권한이 없습니다."),
+    INVALID_INPUT_VALUE(80603, HttpStatus.BAD_REQUEST, "올바른 입력값이 아닙니다.");
 
 
     private final Integer code;

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -108,7 +108,7 @@ public enum ErrorCode {
     
     // 806(comment - helper) part
     IS_NOT_EXIST_COMMENT(80601, HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-    FORBIDDEN_COMMENT_DELETE(80602, HttpStatus.FORBIDDEN, "댓글 삭제 권한이 없습니다.");
+    FORBIDDEN_COMMENT_ACCESS(80602, HttpStatus.FORBIDDEN, "댓글 접근 권한이 없습니다.");
 
 
     private final Integer code;

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -1,10 +1,8 @@
 package com.midas.shootpointer.domain.comment.business;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -22,7 +20,6 @@ import com.midas.shootpointer.global.exception.CustomException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -239,13 +236,13 @@ class CommentManagerTest {
 		Long commentId = comment.getCommentId();
 		
 		given(commentHelper.findCommentByCommentId(commentId)).willReturn(comment);
-		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE))
+		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_ACCESS))
 			.given(commentHelper).validateCommentOwner(comment, otherMemberId);
 		
 		// when-then
 		assertThatThrownBy(() -> commentManager.delete(commentId, otherMemberId))
 			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_DELETE);
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 		
 		then(commentHelper).should(times(1)).findCommentByCommentId(commentId);
 		then(commentHelper).should(times(1)).validateCommentOwner(comment, otherMemberId);
@@ -279,13 +276,13 @@ class CommentManagerTest {
 		Long commentId = comment.getCommentId();
 		
 		given(commentHelper.findCommentByCommentId(commentId)).willReturn(comment);
-		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE))
+		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_ACCESS))
 			.given(commentHelper).validateCommentOwner(comment, null);
 		
 		// when-then
 		assertThatThrownBy(() -> commentManager.delete(commentId, null))
 			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_DELETE);
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 		
 		then(commentHelper).should(times(1)).findCommentByCommentId(commentId);
 		then(commentHelper).should(times(1)).validateCommentOwner(comment, null);

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/CommentManagerTest.java
@@ -317,12 +317,14 @@ class CommentManagerTest {
 		given(commentHelper.findCommentByCommentId(commentId)).willReturn(comment);
 		willDoNothing().given(commentHelper).validateCommentOwner(comment, memberId);
 		willDoNothing().given(commentHelper).validateContentNotBlank(newContent);
-		willDoNothing().given(commentHelper).updateContent(comment, newContent);
+		given(commentHelper.updateContent(comment, newContent)).willReturn(comment); // willReturn으로 변경
 		
 		// when
-		commentManager.update(commentId, newContent, memberId);
+		Comment result = commentManager.update(commentId, newContent, memberId);
 		
 		// then
+		assertThat(result).isNotNull();
+		assertThat(result).isEqualTo(comment);
 		then(commentHelper).should(times(1)).findCommentByCommentId(commentId);
 		then(commentHelper).should(times(1)).validateCommentOwner(comment, memberId);
 		then(commentHelper).should(times(1)).validateContentNotBlank(newContent);
@@ -450,14 +452,16 @@ class CommentManagerTest {
 		willDoNothing().given(commentHelper).validateContentNotBlank(content1);
 		willDoNothing().given(commentHelper).validateContentNotBlank(content2);
 		
-		willDoNothing().given(commentHelper).updateContent(comment1, content1);
-		willDoNothing().given(commentHelper).updateContent(comment2, content2);
+		given(commentHelper.updateContent(comment1, content1)).willReturn(comment1);
+		given(commentHelper.updateContent(comment2, content2)).willReturn(comment2);
 		
 		// when
-		commentManager.update(commentId1, content1, memberId);
-		commentManager.update(commentId2, content2, memberId);
+		Comment result1 = commentManager.update(commentId1, content1, memberId);
+		Comment result2 = commentManager.update(commentId2, content2, memberId);
 		
 		// then
+		assertThat(result1).isNotNull().isEqualTo(comment1);
+		assertThat(result2).isNotNull().isEqualTo(comment2);
 		then(commentHelper).should(times(1)).updateContent(comment1, content1);
 		then(commentHelper).should(times(1)).updateContent(comment2, content2);
 	}

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -88,6 +88,46 @@ class CommentCommandServiceImplTest {
 		then(commentManager).should(times(1)).delete(commentId3, memberId);
 	}
 	
+	@Test
+	@DisplayName("댓글 수정 성공")
+	void update_Success() {
+		// given
+		UUID memberId = UUID.randomUUID();
+		Long commentId = 1L;
+		String content = "수정된 댓글 내용입니다.";
+		
+		willDoNothing().given(commentManager).update(commentId, content, memberId);
+		
+		// when
+		commentCommandService.update(commentId, content, memberId);
+		
+		// then
+		then(commentManager).should(times(1)).update(commentId, content, memberId);
+	}
+	
+	@Test
+	@DisplayName("여러 댓글 수정 성공")
+	void update_Multiple_Success() {
+		// given
+		UUID memberId = UUID.randomUUID();
+		Long commentId1 = 1L;
+		Long commentId2 = 2L;
+		String content1 = "첫번째 댓글 수정";
+		String content2 = "두번째 댓글 수정";
+		
+		willDoNothing().given(commentManager).update(commentId1, content1, memberId);
+		willDoNothing().given(commentManager).update(commentId2, content2, memberId);
+		
+		// when
+		commentCommandService.update(commentId1, content1, memberId);
+		commentCommandService.update(commentId2, content2, memberId);
+		
+		// then
+		then(commentManager).should(times(1)).update(commentId1, content1, memberId);
+		then(commentManager).should(times(1)).update(commentId2, content2, memberId);
+	}
+	
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(UUID.randomUUID())

--- a/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/business/command/CommentCommandServiceImplTest.java
@@ -95,13 +95,16 @@ class CommentCommandServiceImplTest {
 		UUID memberId = UUID.randomUUID();
 		Long commentId = 1L;
 		String content = "수정된 댓글 내용입니다.";
+		Comment comment = createComment();
 		
-		willDoNothing().given(commentManager).update(commentId, content, memberId);
+		given(commentManager.update(commentId, content, memberId)).willReturn(comment);
 		
 		// when
-		commentCommandService.update(commentId, content, memberId);
+		Comment result = commentCommandService.update(commentId, content, memberId);
 		
 		// then
+		assertThat(result).isNotNull();
+		assertThat(result).isEqualTo(comment);
 		then(commentManager).should(times(1)).update(commentId, content, memberId);
 	}
 	
@@ -114,15 +117,19 @@ class CommentCommandServiceImplTest {
 		Long commentId2 = 2L;
 		String content1 = "첫번째 댓글 수정";
 		String content2 = "두번째 댓글 수정";
+		Comment comment1 = createComment();
+		Comment comment2 = createComment();
 		
-		willDoNothing().given(commentManager).update(commentId1, content1, memberId);
-		willDoNothing().given(commentManager).update(commentId2, content2, memberId);
+		given(commentManager.update(commentId1, content1, memberId)).willReturn(comment1);
+		given(commentManager.update(commentId2, content2, memberId)).willReturn(comment2);
 		
 		// when
-		commentCommandService.update(commentId1, content1, memberId);
-		commentCommandService.update(commentId2, content2, memberId);
+		Comment result1 = commentCommandService.update(commentId1, content1, memberId);
+		Comment result2 = commentCommandService.update(commentId2, content2, memberId);
 		
 		// then
+		assertThat(result1).isNotNull().isEqualTo(comment1);
+		assertThat(result2).isNotNull().isEqualTo(comment2);
 		then(commentManager).should(times(1)).update(commentId1, content1, memberId);
 		then(commentManager).should(times(1)).update(commentId2, content2, memberId);
 	}

--- a/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/controller/CommentCommandControllerTest.java
@@ -1,6 +1,5 @@
 package com.midas.shootpointer.domain.comment.controller;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -200,7 +199,7 @@ class CommentCommandControllerTest {
 		// given
 		Long commentId = 1L;
 		
-		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE))
+		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_ACCESS))
 			.given(commentCommandService).delete(eq(commentId), any(UUID.class));
 		
 		// when-then

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
@@ -221,12 +221,14 @@ class CommentHelperImplTest {
 		Comment comment = createComment();
 		String newContent = "수정된 댓글 내용";
 		
-		willDoNothing().given(commentUtil).updateContent(comment, newContent);
+		given(commentUtil.updateContent(comment, newContent)).willReturn(comment);
 		
 		// when
-		commentHelper.updateContent(comment, newContent);
+		Comment result = commentHelper.updateContent(comment, newContent);
 		
 		// then
+		assertThat(result).isNotNull();
+		assertThat(result).isEqualTo(comment);
 		then(commentUtil).should().updateContent(comment, newContent);
 	}
 	

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
@@ -214,6 +214,69 @@ class CommentHelperImplTest {
 		then(commentValidation).should().validateCommentOwner(comment, otherMemberId);
 	}
 	
+	@Test
+	@DisplayName("댓글 내용 업데이트 성공")
+	void updateContent_Success() {
+		// given
+		Comment comment = createComment();
+		String newContent = "수정된 댓글 내용";
+		
+		willDoNothing().given(commentUtil).updateContent(comment, newContent);
+		
+		// when
+		commentHelper.updateContent(comment, newContent);
+		
+		// then
+		then(commentUtil).should().updateContent(comment, newContent);
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 성공")
+	void validateContentNotBlank_Success() {
+		// given
+		String validContent = "유효한 댓글 내용";
+		
+		willDoNothing().given(commentValidation).validateContentNotBlank(validContent);
+		
+		// when
+		commentHelper.validateContentNotBlank(validContent);
+		
+		// then
+		then(commentValidation).should().validateContentNotBlank(validContent);
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 실패 - 빈 문자열")
+	void validateContentNotBlank_Failed_EmptyString() {
+		// given
+		String emptyContent = "   ";
+		
+		willThrow(new CustomException(ErrorCode.INVALID_INPUT_VALUE))
+			.given(commentValidation).validateContentNotBlank(emptyContent);
+		
+		// when-then
+		assertThatThrownBy(() -> commentHelper.validateContentNotBlank(emptyContent))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+		
+		then(commentValidation).should().validateContentNotBlank(emptyContent);
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 실패 - null")
+	void validateContentNotBlank_Failed_Null() {
+		// given
+		willThrow(new CustomException(ErrorCode.INVALID_INPUT_VALUE))
+			.given(commentValidation).validateContentNotBlank(null);
+		
+		// when-then
+		assertThatThrownBy(() -> commentHelper.validateContentNotBlank(null))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+		
+		then(commentValidation).should().validateContentNotBlank(null);
+	}
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(UUID.randomUUID())

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentHelperImplTest.java
@@ -3,7 +3,6 @@ package com.midas.shootpointer.domain.comment.helper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willDoNothing;
@@ -204,13 +203,13 @@ class CommentHelperImplTest {
 		UUID otherMemberId = UUID.randomUUID();
 		Comment comment = createComment();
 		
-		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_DELETE))
+		willThrow(new CustomException(ErrorCode.FORBIDDEN_COMMENT_ACCESS))
 			.given(commentValidation).validateCommentOwner(comment, otherMemberId);
 		
 		// when-then
 		assertThatThrownBy(() -> commentHelper.validateCommentOwner(comment, otherMemberId))
 			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_DELETE);
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 		
 		then(commentValidation).should().validateCommentOwner(comment, otherMemberId);
 	}

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentUtilImplTest.java
@@ -183,6 +183,42 @@ class CommentUtilImplTest {
 		then(commentCommandRepository).should(times(3)).save(any(Comment.class));
 	}
 	
+	@Test
+	@DisplayName("댓글 내용 업데이트 성공")
+	void updateContent_Success() {
+		// given
+		Comment comment = createComment();
+		String newContent = "수정된 댓글 내용";
+		
+		given(commentCommandRepository.save(comment)).willReturn(comment);
+		
+		// when
+		commentUtil.updateContent(comment, newContent);
+		
+		// then
+		then(commentCommandRepository).should(times(1)).save(comment);
+	}
+	
+	@Test
+	@DisplayName("여러 댓글 내용 업데이트 성공")
+	void updateContent_Multiple_Success() {
+		// given
+		Comment comment1 = createComment();
+		Comment comment2 = createComment();
+		String content1 = "첫 번째 수정";
+		String content2 = "두 번째 수정";
+		
+		given(commentCommandRepository.save(any(Comment.class)))
+			.willAnswer(invocation -> invocation.getArgument(0));
+		
+		// when
+		commentUtil.updateContent(comment1, content1);
+		commentUtil.updateContent(comment2, content2);
+		
+		// then
+		then(commentCommandRepository).should(times(2)).save(any(Comment.class));
+	}
+	
 	private Comment createComment() {
 		Member member = Member.builder()
 			.memberId(UUID.randomUUID())

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -113,4 +113,48 @@ class CommentValidationImplTest {
 			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 	}
 	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 성공 - 유효한 내용")
+	void validateContentNotBlank_Success() {
+		// given
+		String validContent = "유효한 댓글 내용입니다.";
+		
+		// when-then
+		assertThatNoException().isThrownBy(() ->
+			commentValidation.validateContentNotBlank(validContent));
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 실패 - 빈 문자열")
+	void validateContentNotBlank_Failed_EmptyString() {
+		// given
+		String emptyContent = "";
+		
+		// when-then
+		assertThatThrownBy(() -> commentValidation.validateContentNotBlank(emptyContent))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 실패 - 공백만 있는 문자열")
+	void validateContentNotBlank_Failed_BlankString() {
+		// given
+		String blankContent = "   ";
+		
+		// when-then
+		assertThatThrownBy(() -> commentValidation.validateContentNotBlank(blankContent))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+	}
+	
+	@Test
+	@DisplayName("댓글 내용 공백 검증 실패 - null")
+	void validateContentNotBlank_Failed_Null() {
+		// when-then
+		assertThatThrownBy(() -> commentValidation.validateContentNotBlank(null))
+			.isInstanceOf(CustomException.class)
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_INPUT_VALUE);
+	}
+	
 }

--- a/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/comment/helper/CommentValidationImplTest.java
@@ -2,7 +2,6 @@ package com.midas.shootpointer.domain.comment.helper;
 
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 
 import com.midas.shootpointer.domain.comment.entity.Comment;
@@ -111,7 +110,7 @@ class CommentValidationImplTest {
 		// when-then
 		assertThatThrownBy(() -> commentValidation.validateCommentOwner(comment, InvalidOwnerId))
 			.isInstanceOf(CustomException.class)
-			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_DELETE);
+			.hasFieldOrPropertyWithValue("errorCode", ErrorCode.FORBIDDEN_COMMENT_ACCESS);
 	}
 	
 }


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #122 

---

## ✅ 작업 사항

➡️ 댓글을 작성한 사용자만이 댓글을 수정할 수 있도록 권한에 따른 로직 처리를 진행하였습니다.

➡️ `ErrorCode`의 삭제 금지 권한을 범용적으로 사용하기 위해 `FORBIDDEN_COMMENT_ACCESS`로 변경하였습니다.

➡️ 기존 기능 명세서에 기재되어있던 Update 관련 구현 사항인 **빈 문자열 입력 시 내용을 삭제한다** 의 내용을 **빈 문자열 입력 시 유효하지 않은 데이터 입력 처리입니다** 로 수정하였습니다.

➡️ Update Mapping 방식을 `@PUTMAPPING`이 아닌 `@PATCHMAPPING` 방식으로 사용함.
-> 댓글 수정의 경우 PUT 방식보다 PATCH 방식이 요청에 포함된 필드만 업데이트하기 때문에 적절함.

---

## ⌨ 기타
[PUT / PATCH Mapping] 에 대한 기술 이론 참고 블로그입니다.
https://ycyeon.tistory.com/145
