### PR TITLE
🛠 Refactor : Highlight domain 아키텍처 수정

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -1,0 +1,108 @@
+package com.midas.shootpointer.domain.highlight.business;
+
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
+import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.highlight.helper.HighlightHelper;
+import com.midas.shootpointer.domain.highlight.mapper.HighlightFactory;
+import com.midas.shootpointer.domain.highlight.mapper.HighlightMapper;
+import com.midas.shootpointer.domain.highlight.service.HighlightStorageService;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.annotation.CustomLog;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HighlightManager {
+    private final HighlightHelper highlightHelper;
+    private final HighlightStorageService highlightStorageService;
+    private final HighlightMapper mapper;
+    private final HighlightFactory factory;
+
+    @Value("${video.path}")
+    private String videoPath;
+
+    /*==========================
+    *
+    *HighlightManager
+    * 여러개의 하이라이트 영상 중 유저가 선택하는 메서드
+    * @parm request : 요청 dto memberId : 멤버 Id
+    * @return 선택된 하이라이트 영상 Id 리스트
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 10. 7.
+    *
+    ==========================**/
+    @Transactional
+    @CustomLog
+    public HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member){
+        List<UUID> selectedIds=request.getSelectedHighlightIds();
+        /**
+         * 1. 유저가 선택 요청한 하이라이트 Id 리스트 -> 엔티티로 가져오기
+         */
+        List<HighlightEntity> highlights = selectedIds.stream()
+                .map(highlightHelper::findHighlightByHighlightId)
+                .toList();
+
+        /*
+         * 2. 선택 수행
+         */
+        highlights.forEach(entity -> entity.select(member));
+
+        return mapper.entityToResponse(selectedIds);
+    }
+
+    /*==========================
+    *
+    *HighlightManager
+    * 1. openCv 에서 생성한 하이라이트 영상들을 비디오 디렉토리에 저장.
+    * 2. PostgreSQL 디렉토리 URL 및 하이라이트 정보 저장.
+    * @parm
+    * @return
+    * @author kimdoyeon
+    * @version 1.0.0
+    * @date 25. 10. 7.
+    *
+    ==========================**/
+    @CustomLog
+    @Transactional
+    public List<HighlightResponse> uploadHighlights(
+            UploadHighlight request,
+            List<MultipartFile> highlights
+    ) {
+        /**
+         * 1. 파일 크기 및 파일 형식 검사
+         */
+        highlightHelper.areValidFiles(highlights);
+
+        /**
+         * 2. 하이라이트 키 / 디렉토리 -> 하이라이트 엔티티 저장
+         */
+        List<String> storedFiles=highlightStorageService.storeHighlights(highlights,request.getHighlightKey());
+
+        /*
+        *   3. 하이라이트 엔티티 생성
+         */
+        List<HighlightEntity> entities=factory.createHighlightEntities(storedFiles,request.getHighlightKey());
+
+        /*
+            4. DB 저장
+         */
+        List<HighlightEntity> savedEntities = highlightHelper.savedAll(entities);
+
+        return savedEntities.stream()
+                .map(mapper::entityToResponse)
+                .toList();
+    }
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -10,10 +10,10 @@ import com.midas.shootpointer.domain.highlight.mapper.HighlightFactory;
 import com.midas.shootpointer.domain.highlight.mapper.HighlightMapper;
 import com.midas.shootpointer.domain.highlight.service.HighlightStorageService;
 import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.member.helper.MemberHelper;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -29,9 +29,7 @@ public class HighlightManager {
     private final HighlightStorageService highlightStorageService;
     private final HighlightMapper mapper;
     private final HighlightFactory factory;
-
-    @Value("${video.path}")
-    private String videoPath;
+    private final MemberHelper memberHelper;
 
     /*==========================
     *
@@ -79,7 +77,8 @@ public class HighlightManager {
     @Transactional
     public List<HighlightResponse> uploadHighlights(
             UploadHighlight request,
-            List<MultipartFile> highlights
+            List<MultipartFile> highlights,
+            UUID memberId
     ) {
         /**
          * 1. 파일 크기 및 파일 형식 검사
@@ -94,7 +93,8 @@ public class HighlightManager {
         /*
         *   3. 하이라이트 엔티티 생성
          */
-        List<HighlightEntity> entities=factory.createHighlightEntities(storedFiles,request.getHighlightKey());
+        Member member=memberHelper.findMemberById(memberId);
+        List<HighlightEntity> entities=factory.createHighlightEntities(storedFiles,request.getHighlightKey(),member);
 
         /*
             4. DB 저장

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
@@ -8,10 +8,11 @@ import com.midas.shootpointer.domain.member.entity.Member;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface HighlightCommandService {
     HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member);
 
-    List<HighlightResponse> uploadHighlights(UploadHighlight request, List<MultipartFile> highlights);
+    List<HighlightResponse> uploadHighlights(UploadHighlight request, List<MultipartFile> highlights, UUID memberId);
 }
 ////

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
@@ -4,14 +4,14 @@ import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.member.entity.Member;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.UUID;
 
 public interface HighlightCommandService {
-    HighlightSelectResponse selectHighlight(HighlightSelectRequest request, String token);
+    HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member);
 
-    List<HighlightResponse> uploadHighlights(String memberId, String token, UploadHighlight request, List<MultipartFile> highlights);
+    List<HighlightResponse> uploadHighlights(UploadHighlight request, List<MultipartFile> highlights);
 }
 ////

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
@@ -17,7 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 public class HighlightCommandServiceImpl implements HighlightCommandService {
-    private HighlightManager manager;
+    private final HighlightManager manager;
     /*==========================
     *
     *HighlightCommandServiceImpl

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
@@ -1,48 +1,23 @@
 package com.midas.shootpointer.domain.highlight.business.command;
 
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
-import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
-import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
-import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
-import com.midas.shootpointer.global.annotation.CustomLog;
-import com.midas.shootpointer.global.common.ErrorCode;
-import com.midas.shootpointer.global.exception.CustomException;
-import com.midas.shootpointer.global.util.jwt.JwtUtil;
+import com.midas.shootpointer.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class HighlightCommandServiceImpl implements HighlightCommandService {
-    private final HighlightCommandRepository highlightCommandRepository;
-    private final HighlightQueryRepository highlightQueryRepository;
-    private final JwtUtil jwtUtil;
-    /*
-    영상 크기 제한 100MB
-     */
-    private static final long MAX_FILE_SIZE = 100L * 1024L * 1024L;
-
-    //영상 저장 경로
-    @Value("${video.path}")
-    private String videoPath;
-
+    private HighlightManager manager;
     /*==========================
     *
     *HighlightCommandServiceImpl
@@ -55,31 +30,8 @@ public class HighlightCommandServiceImpl implements HighlightCommandService {
     *
     ==========================**/
     @Override
-    @CustomLog
-    @Transactional
-    public HighlightSelectResponse selectHighlight(HighlightSelectRequest request, String token) {
-        List<UUID> selectedHighlights = request.getSelectedHighlightIds();
-        UUID memberId = jwtUtil.getMemberId(token);
-
-        //1. 하이라이트Id로 하이라이트 엔티티 가져오기
-        List<HighlightEntity> findByHighlightEntities = selectedHighlights.stream()
-                .map(h -> highlightQueryRepository.findByHighlightId(h)
-                        .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_HIGHLIGHT_ID))).toList();
-
-        //2. 선택한 하이라이트 영상이 요청자의 하이라이트 영상 확인
-        findByHighlightEntities.forEach(h -> {
-            isHighlightVideoSameMember(h.getHighlightId(), memberId);
-            //3. 가져온 하이라이트의 is_selected를 true로 변환
-            h.select();
-            highlightCommandRepository.save(h);
-        });
-
-        //4. 변경 사항 저장
-        highlightCommandRepository.saveAll(findByHighlightEntities);
-
-        return HighlightSelectResponse.builder()
-                .selectedHighlightIds(selectedHighlights)
-                .build();
+    public HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member) {
+        return manager.selectHighlight(request,member);
     }
 
     /*==========================
@@ -94,110 +46,7 @@ public class HighlightCommandServiceImpl implements HighlightCommandService {
     *
     ==========================**/
     @Override
-    @CustomLog
-    @Transactional
-    public List<HighlightResponse> uploadHighlights(String memberId, String token, UploadHighlight request,List<MultipartFile> highlights) {
-        /**
-         *   1.OpenCV에서 받은 하이라이트 영상을 저장.
-         */
-        //파일 크기 및 파일 형식 검사
-        highlights.forEach(highlight -> {
-                    isValidFileSize(highlight);
-                    isValidFileType(highlight);
-                }
-        );
-        List<HighlightEntity> highlightEntities = new ArrayList<>();
-        String highlightKey = request.getHighlightKey();
-        String directoryPath = getDirectoryPath(highlightKey);
-
-        highlights.forEach(h -> {
-            String fileName = UUID.randomUUID() + ".mp4";
-            Path filePath = Paths.get(directoryPath, fileName);
-            try (OutputStream os = Files.newOutputStream(filePath)) {
-                os.write(h.getBytes());
-                highlightEntities.add(
-                        HighlightEntity.builder()
-                                .highlightURL(fileName)
-                                .highlightKey(UUID.fromString(highlightKey))
-                                .build()
-                );
-            } catch (IOException e) {
-                log.error("uploadHighlights : method {} : message",e.getMessage());
-                throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-            }
-        });
-
-        List<HighlightEntity> savedHighlights = highlightCommandRepository.saveAll(highlightEntities);
-
-        //2. 하이라이트 저장 시 멤버 및 키값을 통해 매핑.
-        List<HighlightResponse> responses = new ArrayList<>();
-
-        savedHighlights
-                .forEach(r -> {
-                    HighlightResponse response=HighlightResponse.builder()
-                            .highlightId(r.getHighlightId())
-                            .highlightIdentifier(r.getHighlightKey())
-                            .highlightUrl(r.getHighlightURL())
-                            .build();
-
-                    responses.add(response);
-                });
-
-        //3. 저장한 하이라이트 영상 URL 반환.
-        return responses;
-    }
-
-    /**
-     * 유저의 하이라이트 영상인지 확인 메서드
-     *
-     * @param highlightId 하이라이트 id
-     * @param memberId    유저의 Id
-     */
-    private void isHighlightVideoSameMember(UUID highlightId, UUID memberId) {
-        if (!highlightQueryRepository.isMembersHighlight(memberId, highlightId)) {
-            throw new CustomException(ErrorCode.NOT_MATCH_HIGHLIGHT_VIDEO);
-        }
-    }
-
-    /**
-     * 파일 타입 체크 메서드
-     *
-     * @param file 파일
-     */
-    private void isValidFileType(MultipartFile file) {
-        String contentType = file.getContentType();
-
-        //mp4 파일 형식 검사.
-        if (!contentType.equals("video/mp4")) {
-            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
-        }
-    }
-
-    /**
-     * 파일 사이즈 체크 메서드
-     *
-     * @param file 파일
-     */
-
-    private void isValidFileSize(MultipartFile file) {
-        long fileSize = file.getSize();
-        //파일 사이즈 제한 - 500MB
-        if (fileSize >= MAX_FILE_SIZE) {
-            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
-        }
-    }
-
-    private String getDirectoryPath(String highlightKey) {
-        String directory = videoPath + "/" + highlightKey;
-        Path directoryPath = Paths.get(directory);
-        if (!Files.exists(directoryPath)) {
-            try {
-                Files.createDirectories(directoryPath);
-            } catch (IOException e) {
-                log.error("method : getDirectoryPath message : {}",e.getMessage());
-                throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
-            }
-        }
-        return directoryPath.toString();
+    public List<HighlightResponse> uploadHighlights(UploadHighlight request,List<MultipartFile> highlights) {
+        return manager.uploadHighlights(request,highlights);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -46,7 +47,7 @@ public class HighlightCommandServiceImpl implements HighlightCommandService {
     *
     ==========================**/
     @Override
-    public List<HighlightResponse> uploadHighlights(UploadHighlight request,List<MultipartFile> highlights) {
-        return manager.uploadHighlights(request,highlights);
+    public List<HighlightResponse> uploadHighlights(UploadHighlight request, List<MultipartFile> highlights, UUID memberId) {
+        return manager.uploadHighlights(request,highlights,memberId);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/query/HighlightQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/query/HighlightQueryService.java
@@ -1,0 +1,5 @@
+package com.midas.shootpointer.domain.highlight.business.query;
+
+public interface HighlightQueryService {
+
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/query/HighlightQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/query/HighlightQueryServiceImpl.java
@@ -1,4 +1,4 @@
-package com.midas.shootpointer.domain.highlight.service.query;
+package com.midas.shootpointer.domain.highlight.business.query;
 
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
@@ -42,6 +42,6 @@ public class HighlightController {
             @RequestPart(value = "highlights") List<MultipartFile> highlights
     ) {
         //TODO : JWT 유효성 물어봐야함 -> 재성
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(request,highlights)));
+        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(request,highlights,memberId)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
@@ -1,17 +1,15 @@
 package com.midas.shootpointer.domain.highlight.controller;
 
+import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
-import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.global.dto.ApiResponse;
-import com.midas.shootpointer.global.security.CustomUserDetails;
-import com.midas.shootpointer.global.util.jwt.JwtUtil;
+import com.midas.shootpointer.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -23,15 +21,13 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class HighlightController {
     private final HighlightCommandService highlightCommandService;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/select")
     public ResponseEntity<ApiResponse<HighlightSelectResponse>> selectHighlight(
-            @RequestBody HighlightSelectRequest request,
-            @AuthenticationPrincipal
-            CustomUserDetails userDetails
+            @RequestBody HighlightSelectRequest request
     ) {
-        Member member=userDetails.getMember();
+        Member member = SecurityUtils.getCurrentMember();
+
         return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.selectHighlight(request, member)));
     }
 
@@ -41,7 +37,6 @@ public class HighlightController {
             @RequestPart(value = "uploadHighlightDto") UploadHighlight request,
             @RequestPart(value = "highlights") List<MultipartFile> highlights
     ) {
-        //TODO : JWT 유효성 물어봐야함 -> 재성
         return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(request,highlights,memberId)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightController.java
@@ -5,35 +5,43 @@ import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
 import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
+import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.global.dto.ApiResponse;
+import com.midas.shootpointer.global.security.CustomUserDetails;
+import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/highlight")
 @RequiredArgsConstructor
 public class HighlightController {
     private final HighlightCommandService highlightCommandService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/select")
     public ResponseEntity<ApiResponse<HighlightSelectResponse>> selectHighlight(
-            @RequestHeader("Authorization") String header,
-            @RequestBody HighlightSelectRequest request
+            @RequestBody HighlightSelectRequest request,
+            @AuthenticationPrincipal
+            CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.selectHighlight(request, header)));
+        Member member=userDetails.getMember();
+        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.selectHighlight(request, member)));
     }
 
     @PostMapping("/upload-result")
     public ResponseEntity<ApiResponse<List<HighlightResponse>>> uploadHighlights(
-            @RequestHeader("X-Member-Id") String memberId,
-            @RequestHeader("Authorization") String token,
+            @RequestHeader("X-Member-Id") UUID memberId,
             @RequestPart(value = "uploadHighlightDto") UploadHighlight request,
             @RequestPart(value = "highlights") List<MultipartFile> highlights
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(memberId,token,request,highlights)));
+        //TODO : JWT 유효성 물어봐야함 -> 재성
+        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(request,highlights)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightResponse.java
@@ -26,8 +26,6 @@ public class HighlightResponse {
     @NotBlank(message = "하이라이트 영상 URL은 필수입니다.")
     private String highlightUrl;
 
-    //하이라이트 파일 이름
-    private String highlightName;
 
     //하이라이트 생성 날짜
     private LocalDateTime createdAt;

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/UploadHighlight.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/UploadHighlight.java
@@ -1,18 +1,19 @@
 package com.midas.shootpointer.domain.highlight.dto;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class UploadHighlight {
     @NotEmpty(message = "UUID는 필수값입니다.")
     @Pattern(regexp = "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -2,7 +2,9 @@ package com.midas.shootpointer.domain.highlight.entity;
 
 import com.midas.shootpointer.domain.backnumber.entity.BackNumberEntity;
 import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.entity.BaseEntity;
+import com.midas.shootpointer.global.exception.CustomException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -45,7 +48,18 @@ public class HighlightEntity extends BaseEntity {
     private BackNumberEntity backNumber;
 
 
-    public void select(){
+    /*
+    =========== [ 도메인-행위 ] ==============
+     */
+    public void select(Member actor){
+        //유저의 하이라이트 영상이 아닌경우
+        if (!Objects.equals(actor,member)){
+            throw new CustomException(ErrorCode.IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID);
+        }
+        //이미 선택된 하이라이트 영상인 경우
+        if (Boolean.TRUE.equals(this.isSelected)){
+            throw new CustomException(ErrorCode.EXISTED_SELECTED);
+        }
         this.isSelected=true;
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -13,7 +13,6 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.UuidGenerator;
 
-import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -32,7 +31,7 @@ public class HighlightEntity extends BaseEntity {
     @Column(name = "highlight_url",nullable = false)
     private String highlightURL;
 
-    @Column(name = "highlight_key",nullable = false,unique = true,columnDefinition = "uuid")
+    @Column(name = "highlight_key",nullable = false,columnDefinition = "uuid")
     private UUID highlightKey;
 
     @Column(name = "is_selected")
@@ -53,7 +52,7 @@ public class HighlightEntity extends BaseEntity {
      */
     public void select(Member actor){
         //유저의 하이라이트 영상이 아닌경우
-        if (!Objects.equals(actor,member)){
+        if (!actor.getMemberId().equals(member.getMemberId())){
             throw new CustomException(ErrorCode.IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID);
         }
         //이미 선택된 하이라이트 영상인 경우

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelper.java
@@ -1,4 +1,4 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
-public interface HighlightHelper extends HighlightUtil{
+public interface HighlightHelper extends HighlightUtil,HighlightValidator{
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -20,6 +21,11 @@ public class HighlightHelperImpl implements HighlightHelper{
     @Override
     public HighlightEntity findHighlightByHighlightId(UUID highlightId) {
         return highlightUtil.findHighlightByHighlightId(highlightId);
+    }
+
+    @Override
+    public List<HighlightEntity> savedAll(List<HighlightEntity> entities) {
+        return highlightUtil.savedAll(entities);
     }
 
     @Override
@@ -50,5 +56,10 @@ public class HighlightHelperImpl implements HighlightHelper{
     @Override
     public boolean isExistDirectory(String directory) {
         return highlightValidator.isExistDirectory(directory);
+    }
+
+    @Override
+    public void areValidFiles(List<MultipartFile> files) {
+
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -3,6 +3,7 @@ package com.midas.shootpointer.domain.highlight.helper;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
 
@@ -10,6 +11,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class HighlightHelperImpl implements HighlightHelper{
     private final HighlightUtilImpl highlightUtil;
+    private final HighlightValidator highlightValidator;
     @Override
     public String getDirectoryPath(String highlightKey) {
         return highlightUtil.getDirectoryPath(highlightKey);
@@ -20,4 +22,33 @@ public class HighlightHelperImpl implements HighlightHelper{
         return highlightUtil.findHighlightByHighlightId(highlightId);
     }
 
+    @Override
+    public boolean filesExist(String directory) {
+        return highlightValidator.filesExist(directory);
+    }
+
+    @Override
+    public void isExistHighlightId(UUID highlightId) {
+        highlightValidator.isExistHighlightId(highlightId);
+    }
+
+    @Override
+    public void isValidMembersHighlight(UUID highlightId, UUID memberId) {
+        highlightValidator.isValidMembersHighlight(highlightId,memberId);
+    }
+
+    @Override
+    public void isValidMp4File(MultipartFile file) {
+        highlightValidator.isValidMp4File(file);
+    }
+
+    @Override
+    public void isValidFileSize(MultipartFile file) {
+        highlightValidator.isValidMp4File(file);
+    }
+
+    @Override
+    public boolean isExistDirectory(String directory) {
+        return highlightValidator.isExistDirectory(directory);
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Component
 @RequiredArgsConstructor
 public class HighlightHelperImpl implements HighlightHelper{
-    private final HighlightUtilImpl highlightUtil;
+    private final HighlightUtil highlightUtil;
     private final HighlightValidator highlightValidator;
     @Override
     public String getDirectoryPath(String highlightKey) {
@@ -50,7 +50,7 @@ public class HighlightHelperImpl implements HighlightHelper{
 
     @Override
     public void isValidFileSize(MultipartFile file) {
-        highlightValidator.isValidMp4File(file);
+        highlightValidator.isValidFileSize(file);
     }
 
     @Override
@@ -60,6 +60,6 @@ public class HighlightHelperImpl implements HighlightHelper{
 
     @Override
     public void areValidFiles(List<MultipartFile> files) {
-
+        highlightValidator.areValidFiles(files);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -2,9 +2,11 @@ package com.midas.shootpointer.domain.highlight.helper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface HighlightUtil {
     String getDirectoryPath(String highlightKey);
     HighlightEntity findHighlightByHighlightId(UUID highlightId);
+    List<HighlightEntity> savedAll(List<HighlightEntity> entities);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -5,7 +5,6 @@ import com.midas.shootpointer.domain.highlight.repository.HighlightCommandReposi
 import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,15 +18,19 @@ import java.util.UUID;
 
 @Component
 @Slf4j
-@RequiredArgsConstructor
 public class HighlightUtilImpl implements HighlightUtil{
     //영상 저장 경로
-    @Value("${video.path}")
-    private String videoPath;
+    private final String videoPath;
 
     private final HighlightQueryRepository highlightQueryRepository;
 
     private final HighlightCommandRepository highlightCommandRepository;
+
+    public HighlightUtilImpl(@Value("${video.path}") String videoPath, HighlightQueryRepository highlightQueryRepository, HighlightCommandRepository highlightCommandRepository){
+        this.videoPath=videoPath;
+        this.highlightQueryRepository = highlightQueryRepository;
+        this.highlightCommandRepository = highlightCommandRepository;
+    }
 
     @Override
     public String getDirectoryPath(String highlightKey) {

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
 import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
@@ -13,6 +14,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.UUID;
 
 @Component
@@ -25,6 +27,7 @@ public class HighlightUtilImpl implements HighlightUtil{
 
     private final HighlightQueryRepository highlightQueryRepository;
 
+    private final HighlightCommandRepository highlightCommandRepository;
 
     @Override
     public String getDirectoryPath(String highlightKey) {
@@ -45,6 +48,11 @@ public class HighlightUtilImpl implements HighlightUtil{
     public HighlightEntity findHighlightByHighlightId(UUID highlightId) {
         return highlightQueryRepository.findByHighlightId(highlightId)
                 .orElseThrow(()->new CustomException(ErrorCode.NOT_EXIST_HIGHLIGHT));
+    }
+
+    @Override
+    public List<HighlightEntity> savedAll(List<HighlightEntity> entities) {
+        return highlightCommandRepository.saveAll(entities);
     }
 
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.highlight.helper;
 
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface HighlightValidator {
@@ -11,4 +12,5 @@ public interface HighlightValidator {
     void isValidMp4File(MultipartFile file);
     void isValidFileSize(MultipartFile file);
     boolean isExistDirectory(String directory);
+    void areValidFiles(List<MultipartFile> files);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
@@ -1,0 +1,14 @@
+package com.midas.shootpointer.domain.highlight.helper;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public interface HighlightValidator {
+    boolean filesExist(String directory);
+    void isExistHighlightId(UUID highlightId);
+    void isValidMembersHighlight(UUID highlightId,UUID memberId);
+    void isValidMp4File(MultipartFile file);
+    void isValidFileSize(MultipartFile file);
+    boolean isExistDirectory(String directory);
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
@@ -8,13 +8,18 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 public class HighlightValidatorImpl implements HighlightValidator{
+    private static final Set<String> ALLOWED_VIDEO_TYPES = Set.of(
+            "video/mp4"
+    );
     /**
      * 영상 크기 제한 500MB
      */
@@ -45,7 +50,7 @@ public class HighlightValidatorImpl implements HighlightValidator{
     @Override
     public void isValidMp4File(MultipartFile file) {
         String contentType=file.getContentType();
-        if(!contentType.equals("video/mp4")){
+        if(!ALLOWED_VIDEO_TYPES.contains(contentType)){
             throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
         }
     }
@@ -60,6 +65,17 @@ public class HighlightValidatorImpl implements HighlightValidator{
 
     @Override
     public boolean isExistDirectory(String directory) {
-        return Files.exists(Paths.get(directory));
+        if (directory == null || directory.isBlank()) {
+            return false;
+        }
+
+        Path path;
+        try {
+            path = Paths.get(directory);
+        } catch (InvalidPathException e) {
+            return false;
+        }
+
+        return Files.exists(path) && Files.isDirectory(path);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
@@ -11,6 +11,7 @@ import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -77,5 +78,13 @@ public class HighlightValidatorImpl implements HighlightValidator{
         }
 
         return Files.exists(path) && Files.isDirectory(path);
+    }
+
+    @Override
+    public void areValidFiles(List<MultipartFile> files) {
+        files.forEach(file->{
+            isValidFileSize(file);
+            isValidMp4File(file);
+        });
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
@@ -1,0 +1,65 @@
+package com.midas.shootpointer.domain.highlight.helper;
+
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class HighlightValidatorImpl implements HighlightValidator{
+    /**
+     * 영상 크기 제한 500MB
+     */
+    private static final long MAX_FILE_SIZE = 500L * 1024L * 1024L;
+    private final HighlightQueryRepository highlightQueryRepository;
+
+    @Override
+    public boolean filesExist(String directory) {
+        Path directoryPath= Paths.get(directory);
+        return Files.exists(directoryPath);
+    }
+
+    @Override
+    public void isExistHighlightId(UUID highlightId) {
+        if (!highlightQueryRepository.existsByHighlightId(highlightId)){
+            throw new CustomException(ErrorCode.NOT_EXIST_HIGHLIGHT);
+        }
+    }
+
+    @Override
+    public void isValidMembersHighlight(UUID highlightId, UUID memberId) {
+        if (!highlightQueryRepository.isMembersHighlight(memberId,highlightId)){
+            throw new CustomException(ErrorCode.NOT_MATCH_HIGHLIGHT_VIDEO);
+        }
+    }
+
+
+    @Override
+    public void isValidMp4File(MultipartFile file) {
+        String contentType=file.getContentType();
+        if(!contentType.equals("video/mp4")){
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+    }
+
+    @Override
+    public void isValidFileSize(MultipartFile file) {
+        long fileSize=file.getSize();
+        if (fileSize>=MAX_FILE_SIZE){
+            throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    @Override
+    public boolean isExistDirectory(String directory) {
+        return Files.exists(Paths.get(directory));
+    }
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.member.entity.Member;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -8,10 +9,11 @@ import java.util.UUID;
 
 @Component
 public class HighlightFactory {
-    public List<HighlightEntity> createHighlightEntities(List<String> fileNames,String highlightKey){
+    public List<HighlightEntity> createHighlightEntities(List<String> fileNames, String highlightKey, Member member){
         UUID key=UUID.fromString(highlightKey);
         return fileNames.stream()
                 .map(name -> HighlightEntity.builder()
+                        .member(member)
                         .highlightURL(name)
                         .highlightKey(key)
                         .build())

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
@@ -1,0 +1,20 @@
+package com.midas.shootpointer.domain.highlight.mapper;
+
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class HighlightFactory {
+    public List<HighlightEntity> createHighlightEntities(List<String> fileNames,String highlightKey){
+        UUID key=UUID.fromString(highlightKey);
+        return fileNames.stream()
+                .map(name -> HighlightEntity.builder()
+                        .highlightURL(name)
+                        .highlightKey(key)
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
@@ -1,7 +1,13 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 
-public interface HighlightMapper {
+import java.util.List;
+import java.util.UUID;
 
+public interface HighlightMapper {
+    HighlightSelectResponse entityToResponse(List<UUID> selectedHighlights);
+    HighlightResponse entityToResponse(HighlightEntity highlight);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -1,0 +1,32 @@
+package com.midas.shootpointer.domain.highlight.mapper;
+
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class HighlightMapperImpl implements HighlightMapper{
+
+    @Override
+    public HighlightSelectResponse entityToResponse(List<UUID> selectedHighlights) {
+        return HighlightSelectResponse.builder()
+                .selectedHighlightIds(selectedHighlights)
+                .build();
+    }
+
+    @Override
+    public HighlightResponse entityToResponse(HighlightEntity highlight) {
+        return HighlightResponse.builder()
+                .createdAt(highlight.getCreatedAt())
+                .highlightId(highlight.getHighlightId())
+                .highlightIdentifier(highlight.getHighlightKey())
+                .highlightUrl(highlight.getHighlightURL())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -1,7 +1,6 @@
 package com.midas.shootpointer.domain.highlight.repository;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
-import com.midas.shootpointer.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +22,6 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
                    "WHERE M.member_id=:memberId " +
                    "AND H.highlight_id=:highlightId ) ",nativeQuery = true)
     boolean existsByHighlightIdAndMember(@Param("highlightId") UUID highlightId, @Param("memberId") UUID memberId);
+
+    boolean existsByHighlightId(UUID highlightId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/service/HighlightStorageService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/service/HighlightStorageService.java
@@ -1,0 +1,44 @@
+package com.midas.shootpointer.domain.highlight.service;
+
+import com.midas.shootpointer.domain.highlight.helper.HighlightHelper;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HighlightStorageService {
+    private final HighlightHelper highlightHelper;
+
+    public List<String> storeHighlights(List<MultipartFile> highlights, String highlightKey) {
+        String directoryPath = highlightHelper.getDirectoryPath(highlightKey);
+        List<String> fileNames = new ArrayList<>();
+
+        for (MultipartFile file : highlights) {
+            String fileName = UUID.randomUUID() + ".mp4";
+            Path filePath = Paths.get(directoryPath, fileName);
+            try (OutputStream os = Files.newOutputStream(filePath)) {
+                os.write(file.getBytes());
+                fileNames.add(fileName);
+            } catch (IOException e) {
+                log.error("파일 저장 실패: {}", e.getMessage());
+                throw new CustomException(ErrorCode.FILE_UPLOAD_FAILED);
+            }
+        }
+
+        return fileNames;
+    }
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/service/query/HighlightQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/service/query/HighlightQueryService.java
@@ -1,5 +1,0 @@
-package com.midas.shootpointer.domain.highlight.service.query;
-
-public interface HighlightQueryService {
-
-}

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -1,10 +1,12 @@
 package com.midas.shootpointer.domain.member.entity;
 
+import com.midas.shootpointer.global.config.JpaAuditingConfig;
 import com.midas.shootpointer.global.entity.BaseEntity;
 import com.midas.shootpointer.global.util.encrypt.EncryptionHelper;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
+import org.springframework.context.annotation.Import;
 
 import java.util.*;
 
@@ -13,6 +15,7 @@ import java.util.*;
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Import(JpaAuditingConfig.class)
 @Table(name = "member")
 public class Member extends BaseEntity {
 

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -33,7 +33,7 @@ public class Member extends BaseEntity {
         if(this==o) return true;
         if(!(o instanceof Member)) return false;
         Member other=(Member) o;
-        return Objects.equals(memberId,other.memberId);
+        return Objects.equals(this.memberId,other.memberId);
     }
 
     @Override

--- a/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/entity/Member.java
@@ -28,4 +28,16 @@ public class Member extends BaseEntity {
     @Convert(converter = EncryptionHelper.class)
     private String email;
 
+    @Override
+    public boolean equals(Object o){
+        if(this==o) return true;
+        if(!(o instanceof Member)) return false;
+        Member other=(Member) o;
+        return Objects.equals(memberId,other.memberId);
+    }
+
+    @Override
+    public int hashCode(){
+        return Objects.hashCode(memberId);
+    }
 }

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 
      * <p>
      * - Package
+     * entity                      0
      * controller:                 1
      * service:                    2
      * repository:                 3
@@ -93,9 +94,11 @@ public enum ErrorCode {
     INVALID_DELETE_LIKE(70602,HttpStatus.BAD_REQUEST,"잘못된 좋아요 요청입니다."),
     NOT_FOUND_LIKE(70603,HttpStatus.NOT_FOUND,"좋아요를 찾을 수 없습니다."),
 
+    //200(highlight - entity) part
+    IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID(20001,HttpStatus.FORBIDDEN,"유저의 하이라이트 영상이 아닙니다."),
+    EXISTED_SELECTED(20002,HttpStatus.BAD_REQUEST,"이미 선택된 하이라이트 영상입니다."),
 
-    //206(highlight - helper) part
-    IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID(20601,HttpStatus.FORBIDDEN,"유저의 하이라이트 영상이 아닙니다."),
+    //206(highlight - helper) part,
     IS_NOT_CORRECT_HASH_TAG(20602,HttpStatus.BAD_REQUEST,"잘못된 카테고리 입력입니다."),
     NOT_EXIST_HIGHLIGHT(20603,HttpStatus.FORBIDDEN,"존재하지 않는 하이라이트 영상입니다."),
 
@@ -107,6 +110,9 @@ public enum ErrorCode {
 
     //607(post-business) part
     IS_NOT_EXIST_POST(60701,HttpStatus.FORBIDDEN,"존재하지 않는 게시물입니다."),
+
+
+
     ;
 
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -20,3 +20,6 @@ spring:
     restclient:
       sniffer:
         interval: 5m
+
+video:
+  path: ${java.io.tmpdir}/videos

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
   # JPA 설정
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:create-drop}
     database-platform: ${SPRING_JPA_DATABASE_PLATFORM:org.hibernate.dialect.PostgreSQLDialect}
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -119,7 +119,7 @@ kakao:
     uri: https://kapi.kakao.com
 
 opencv:
-  url: http://localhost:8888
+  url: http://tkv00.ddns.net:8000
   api:
     post:
       send-image: /api/send-img

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -122,7 +122,7 @@ opencv:
   url: http://tkv00.ddns.net:8000
   api:
     post:
-      send-image: /api/send-img
+      send-image: /player/ocr
     get:
       fetch-video: /api/fetch-video
     proxy:

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
@@ -1,0 +1,171 @@
+package com.midas.shootpointer.domain.highlight.business;
+
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
+import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.highlight.mapper.HighlightFactory;
+import com.midas.shootpointer.domain.highlight.mapper.HighlightMapper;
+import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
+import com.midas.shootpointer.domain.highlight.service.HighlightStorageService;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.member.repository.MemberCommandRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 통합 테스트 진행
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+class HighlightManagerTest {
+    @Autowired
+    private HighlightManager highlightManager;
+
+    @Autowired
+    private HighlightStorageService highlightStorageService;
+
+    @Autowired
+    private HighlightMapper mapper;
+
+    @Autowired
+    private HighlightFactory factory;
+
+    @Autowired
+    private HighlightCommandRepository repository;
+
+    @Autowired
+    private MemberCommandRepository memberCommandRepository;
+
+    @TempDir
+    private static Path tempDir;
+
+    @DynamicPropertySource
+    static void registerProperties(DynamicPropertyRegistry registry) {
+        registry.add("video.path", () -> tempDir.toString());
+    }
+
+    @AfterEach
+    void cleanUp(){
+        repository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("하이라이트 영상 객체를 호출하고 가져온 하이라이트 영상의 is_selected를 true 상태로 변환합니다.")
+    void selectHighlight(){
+        //given
+        //하이라이트 영상 URL 저장
+        UUID highlightKey=UUID.randomUUID();
+        Member member=memberCommandRepository.save(makeMember());
+        List<HighlightEntity> highlightEntities=List.of(
+                makeHighlightEntity("url",highlightKey,member),
+                makeHighlightEntity("url",highlightKey,member),
+                makeHighlightEntity("url",highlightKey,member)
+        );
+        highlightEntities=repository.saveAll(highlightEntities);
+        List<UUID> selectedIds=highlightEntities.stream()
+                .map(HighlightEntity::getHighlightId)
+                .toList();
+
+        HighlightSelectRequest request=HighlightSelectRequest.builder()
+                .selectedHighlightIds(selectedIds)
+                .build();
+
+
+        //when
+        HighlightSelectResponse response=highlightManager.selectHighlight(request,member);
+
+        //then
+        assertThat(response).isNotNull();
+        assertThat(response.getSelectedHighlightIds()).hasSize(3);
+        assertThat(response.getSelectedHighlightIds().get(0)).isEqualTo(selectedIds.get(0));
+        assertThat(response.getSelectedHighlightIds().get(1)).isEqualTo(selectedIds.get(1));
+        assertThat(response.getSelectedHighlightIds().get(2)).isEqualTo(selectedIds.get(2));
+
+    }
+
+
+    @Test
+    @DisplayName("실제 하이라이트 영상을 저장하고 엔티티를 DB에 저장한 후 DTO로 변환합니다.")
+    void uploadHighlights(){
+        //given
+        Member member=memberCommandRepository.save(
+                Member.builder()
+                        .username("test")
+                        .email("test@naver.com")
+                        .build()
+        );
+        UUID highlightKey=UUID.randomUUID();
+        LocalDateTime now=LocalDateTime.now();
+        UploadHighlight request=UploadHighlight.builder()
+                .highlightKey(highlightKey.toString())
+                .createAt(now)
+                .build();
+        byte[] content=new byte[100];
+        MultipartFile file1=new MockMultipartFile("file1","video1.mp4","video/mp4",content);
+        MultipartFile file2=new MockMultipartFile("file2","video2.mp4","video/mp4",content);
+        List<MultipartFile> files=List.of(file1,file2);
+
+
+        //when
+        List<HighlightResponse> result=highlightManager.uploadHighlights(request,files,member.getMemberId());
+
+        //then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getHighlightUrl()).contains(".mp4");
+        assertThat(result.get(1).getHighlightUrl()).contains(".mp4");
+
+        //실제 디렉ㅌ리 생성 여부
+        Path highlightDir=tempDir.resolve(highlightKey.toString());
+        assertThat(Files.exists(highlightDir)).isTrue();
+
+        //저장된 파일 존재 여부 검증
+        try (var stream = Files.list(highlightDir)) {
+            List<String> storedFiles = stream.map(Path::getFileName)
+                    .map(Path::toString)
+                    .toList();
+            assertThat(storedFiles).hasSize(2);
+            assertThat(storedFiles.get(0)).endsWith(".mp4");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        //DB 저장 검증
+        List<HighlightEntity> saved = repository.findAll();
+        assertThat(saved).hasSize(2);
+        assertThat(saved.get(0).getHighlightKey()).isEqualTo(highlightKey);
+    }
+    private HighlightEntity makeHighlightEntity(String url,UUID highlightKey,Member member){
+        return HighlightEntity.builder()
+                .highlightURL(url)
+                .highlightKey(highlightKey)
+                .member(member)
+                .build();
+    }
+
+    private Member makeMember(){
+        return Member.builder()
+                .email("test@naver.com")
+                .username("test")
+                .build();
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
@@ -55,11 +55,12 @@ class HighlightCommandServiceImplTest {
                 .highlightKey("UUID")
                 .build();
         List<MultipartFile> list=new ArrayList<>();
+        UUID memberId=UUID.randomUUID();
 
         //when
-        commandService.uploadHighlights(request,list);
+        commandService.uploadHighlights(request,list,memberId);
 
         //then
-        verify(highlightManager,times(1)).uploadHighlights(request,list);
+        verify(highlightManager,times(1)).uploadHighlights(request,list,memberId);
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
@@ -1,3 +1,4 @@
+/*
 package com.midas.shootpointer.domain.highlight.business.command;
 
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
@@ -117,9 +118,11 @@ class HighlightCommandServiceImplTest {
         assertThat(customException).isNotNull();
         assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.NOT_MATCH_HIGHLIGHT_VIDEO);
     }
-    /**
+    */
+/**
      * Mock HighlightSelectRequest
-     */
+     *//*
+
     private HighlightSelectRequest mockHighlightSelectRequest(List<UUID> highlightIds){
         return HighlightSelectRequest
                 .builder()
@@ -128,4 +131,4 @@ class HighlightCommandServiceImplTest {
     }
 
 
-}
+}*/

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
@@ -1,134 +1,65 @@
-/*
 package com.midas.shootpointer.domain.highlight.business.command;
 
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
-import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
-import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
-import com.midas.shootpointer.global.common.ErrorCode;
-import com.midas.shootpointer.global.exception.CustomException;
-import com.midas.shootpointer.global.util.jwt.JwtUtil;
+import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class HighlightCommandServiceImplTest {
     @InjectMocks
-    private HighlightCommandServiceImpl highlightCommandService;
+    private HighlightCommandServiceImpl commandService;
 
     @Mock
-    private JwtUtil jwtUtil;
+    private HighlightManager highlightManager;
 
-    @Mock
-    private HighlightQueryRepository highlightQueryRepository;
-
-    @Mock
-    private HighlightCommandRepository highlightCommandRepository;
-
+    @DisplayName("manager.selectHighlight(HighlightSelectRequest, Member)가 실행되는지 검증합니다.")
     @Test
-    @DisplayName("하이라이트 영상을 선택하여 is_selected column를 true로 변환합니다.")
-    void selectHighlight_SUCCEESS() {
+    void selectHighlight(){
         //given
-        UUID mockMemberId=UUID.randomUUID();
-        UUID highlightId1=UUID.randomUUID();
-        UUID highlightId2=UUID.randomUUID();
-
-        HighlightEntity highlight1=mock(HighlightEntity.class);
-        HighlightEntity highlight2=mock(HighlightEntity.class);
-        HighlightSelectRequest mockRequest=mockHighlightSelectRequest(List.of(highlightId1,highlightId2));
-        String mockToken="test-token";
-
-        when(jwtUtil.getMemberId(any(String.class))).thenReturn(mockMemberId);
-        when(highlightQueryRepository.findByHighlightId(highlightId1)).thenReturn(Optional.of(highlight1));
-        when(highlightQueryRepository.findByHighlightId(highlightId2)).thenReturn(Optional.of(highlight2));
-
-        when(highlightQueryRepository.isMembersHighlight(any(),any())).thenReturn(true);
-        when(highlightQueryRepository.isMembersHighlight(any(),any())).thenReturn(true);
+        HighlightSelectRequest request=HighlightSelectRequest.builder()
+                .selectedHighlightIds(List.of(UUID.randomUUID()))
+                .build();
+        Member member=Member.builder()
+                .memberId(UUID.randomUUID())
+                .username("test")
+                .email("test@naver.com")
+                .build();
 
         //when
-        HighlightSelectResponse response=highlightCommandService.selectHighlight(mockRequest,mockToken);
+        commandService.selectHighlight(request,member);
 
         //then
-        verify(highlight1).select();
-        verify(highlight2).select();
-        verify(highlightCommandRepository).saveAll(List.of(highlight1,highlight2));
-
-        assertThat(response.getSelectedHighlightIds()).isEqualTo(mockRequest.getSelectedHighlightIds());
+        verify(highlightManager, times(1)).selectHighlight(request,member);
     }
 
+    @DisplayName("manager.uploadHighlights(UploadHighlight,List<MultipartFile>)가 실행되는지 검증합니다.")
     @Test
-    @DisplayName("하이라이트 영상 선택 시 존재하지 않는 하이라이트 영상이면 예외를 반환합니다._FAIL")
-    void selectHighlight_of_notExisted_highlight_FAIL() {
+    void uploadHighlights(){
         //given
-        UUID mockMemberId=UUID.randomUUID();
-        UUID highlightId1=UUID.randomUUID();
-        UUID highlightId2=UUID.randomUUID();
-
-        HighlightSelectRequest mockRequest=mockHighlightSelectRequest(List.of(highlightId1,highlightId2));
-        String mockToken="test-token";
-
-        when(jwtUtil.getMemberId(any(String.class))).thenReturn(mockMemberId);
-        when(highlightQueryRepository.findByHighlightId(highlightId1)).thenReturn(Optional.empty());
-
-        //when & then
-        CustomException customException=catchThrowableOfType(()->
-                highlightCommandService.selectHighlight(mockRequest,mockToken),
-                CustomException.class
-        );
-        assertThat(customException).isNotNull();
-        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND_HIGHLIGHT_ID);
-    }
-
-    @Test
-    @DisplayName("하이라이트 영상을 선택시 유저의 하이라이트 영상이 아니면 예외를 반환합니다._FAIL")
-    void selectHighlight_not_same_highlightVideo_FAIL() {
-        //given
-        UUID mockMemberId=UUID.randomUUID();
-        UUID highlightId1=UUID.randomUUID();
-        UUID highlightId2=UUID.randomUUID();
-
-        HighlightEntity highlight1=mock(HighlightEntity.class);
-        HighlightEntity highlight2=mock(HighlightEntity.class);
-        HighlightSelectRequest mockRequest=mockHighlightSelectRequest(List.of(highlightId1,highlightId2));
-        String mockToken="test-token";
-
-        when(jwtUtil.getMemberId(any(String.class))).thenReturn(mockMemberId);
-        when(highlightQueryRepository.findByHighlightId(highlightId1)).thenReturn(Optional.of(highlight1));
-        when(highlightQueryRepository.findByHighlightId(highlightId2)).thenReturn(Optional.of(highlight2));
-
-        when(highlightQueryRepository.isMembersHighlight(any(),any())).thenReturn(false);
-
-        //when & then
-        CustomException customException=catchThrowableOfType(()->
-                    highlightCommandService.selectHighlight(mockRequest,mockToken),
-                    CustomException.class
-        );
-        assertThat(customException).isNotNull();
-        assertThat(customException.getErrorCode()).isEqualTo(ErrorCode.NOT_MATCH_HIGHLIGHT_VIDEO);
-    }
-    */
-/**
-     * Mock HighlightSelectRequest
-     *//*
-
-    private HighlightSelectRequest mockHighlightSelectRequest(List<UUID> highlightIds){
-        return HighlightSelectRequest
-                .builder()
-                .selectedHighlightIds(highlightIds)
+        UploadHighlight request=UploadHighlight.builder()
+                .highlightKey("UUID")
                 .build();
+        List<MultipartFile> list=new ArrayList<>();
+
+        //when
+        commandService.uploadHighlights(request,list);
+
+        //then
+        verify(highlightManager,times(1)).uploadHighlights(request,list);
     }
-
-
-}*/
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
@@ -1,3 +1,4 @@
+/*
 package com.midas.shootpointer.domain.highlight.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,21 +79,25 @@ class HighlightControllerTest {
         verify(highlightCommandService).selectHighlight(any(HighlightSelectRequest.class),any(String.class));
     }
 
-    /**
+    */
+/**
      * Mock HighlightSelectResponse
-     */
+     *//*
+
     private HighlightSelectResponse mockHighlightSelectResponse(List<UUID> uuids){
         return HighlightSelectResponse.builder()
                 .selectedHighlightIds(uuids)
                 .build();
     }
 
-    /**
+    */
+/**
      * Mock HighlightSelectRequest
-     */
+     *//*
+
     private HighlightSelectRequest mockHighlightSelectRequest(List<UUID> uuids){
         return HighlightSelectRequest.builder()
                 .selectedHighlightIds(uuids)
                 .build();
     }
-}
+}*/

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
@@ -1,56 +1,55 @@
-/*
 package com.midas.shootpointer.domain.highlight.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.midas.shootpointer.WithMockCustomMember;
+import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
-import org.junit.jupiter.api.BeforeEach;
+import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import static org.hamcrest.Matchers.containsInAnyOrder;
 
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Mockito.*;
-
-@ExtendWith(MockitoExtension.class)
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@AutoConfigureMockMvc
+@SpringBootTest
+@ActiveProfiles("test")
 class HighlightControllerTest {
+    @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
     private ObjectMapper objectMapper;
-    @Mock
+
+    @MockitoBean
     private HighlightCommandService highlightCommandService;
 
-    @InjectMocks
-    private HighlightController highlightController;
-
-    @BeforeEach
-    void setUp(){
-        mockMvc= MockMvcBuilders.standaloneSetup(highlightController).build();
-        objectMapper=new ObjectMapper();
-    }
 
     @Test
     @DisplayName("하이라이트 영상 선택 POST 요청 성공시 HighlightSelectResponse를 반환합니다._SUCCESS")
+    @WithMockCustomMember
     void selectHighlight() throws Exception {
         //given
         String url="/api/highlight/select";
-        String token="test-token";
 
         UUID highlight1=UUID.randomUUID();
         UUID highlight2=UUID.randomUUID();
@@ -59,13 +58,12 @@ class HighlightControllerTest {
         HighlightSelectResponse expectedResponse=mockHighlightSelectResponse(uuids);
         HighlightSelectRequest request=mockHighlightSelectRequest(uuids);
 
-        when(highlightCommandService.selectHighlight(any(HighlightSelectRequest.class),any(String.class)))
+        when(highlightCommandService.selectHighlight(any(HighlightSelectRequest.class),any(Member.class)))
                 .thenReturn(expectedResponse);
 
         //when & then
         mockMvc.perform(post(url)
                         .content(objectMapper.writeValueAsString(request))
-                        .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("OK"))
@@ -76,13 +74,80 @@ class HighlightControllerTest {
                 )))
                 .andDo(print());
 
-        verify(highlightCommandService).selectHighlight(any(HighlightSelectRequest.class),any(String.class));
+        verify(highlightCommandService).selectHighlight(any(HighlightSelectRequest.class),any(Member.class));
     }
 
-    */
-/**
+
+    @Test
+    @DisplayName("생성된 하이라이트 영상을 저장하고 성공시 List<HighlightResponse>를 반환합니다.._SUCCESS")
+    @WithMockCustomMember
+    void uploadHighlights() throws Exception {
+        //given
+        String url="/api/highlight/upload-result";
+
+        UUID memberId=UUID.randomUUID();
+        UUID highlightKey=UUID.randomUUID();
+        UUID highlightId1=UUID.randomUUID();
+        UUID highlightId2=UUID.randomUUID();
+
+        LocalDateTime time=LocalDateTime.now();
+
+        UploadHighlight request=UploadHighlight.builder()
+                        .createAt(LocalDateTime.now())
+                        .highlightKey(highlightKey.toString())
+                        .build();
+
+        byte[] content=new byte[10];
+        MockMultipartFile video1=new MockMultipartFile("highlights","video1.mp4","video/mp4",content);
+        MockMultipartFile video2=new MockMultipartFile("highlights","video2.mp4","video/mp4",content);
+        MockMultipartFile dto=new MockMultipartFile(
+                "uploadHighlightDto","",
+                "application/json",
+                objectMapper.writeValueAsBytes(request)
+        );
+
+        List<HighlightResponse> expectedResponse=List.of(
+                HighlightResponse.builder()
+                        .createdAt(time)
+                        .highlightId(highlightId1)
+                        .highlightIdentifier(highlightKey)
+                        .highlightUrl("url")
+                        .build(),
+                HighlightResponse.builder()
+                        .createdAt(time)
+                        .highlightId(highlightId2)
+                        .highlightIdentifier(highlightKey)
+                        .highlightUrl("url")
+                        .build()
+        );
+
+        when(highlightCommandService.uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class)))
+                .thenReturn(expectedResponse);
+
+        //when & then
+        mockMvc.perform(multipart(url)
+                        .file(video1)
+                        .file(video2)
+                        .file(dto)
+                        .header("X-Member-Id",memberId.toString())
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].highlightId").value(highlightId1.toString()))
+                .andExpect(jsonPath("$.data[0].highlightIdentifier").value(highlightKey.toString()))
+                .andExpect(jsonPath("$.data[0].highlightUrl").value("url"))
+
+                .andExpect(jsonPath("$.data[1].highlightId").value(highlightId2.toString()))
+                .andExpect(jsonPath("$.data[1].highlightIdentifier").value(highlightKey.toString()))
+                .andExpect(jsonPath("$.data[1].highlightUrl").value("url"))
+                .andDo(print());
+
+        verify(highlightCommandService).uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class));
+    }
+    /*
      * Mock HighlightSelectResponse
-     *//*
+     */
 
     private HighlightSelectResponse mockHighlightSelectResponse(List<UUID> uuids){
         return HighlightSelectResponse.builder()
@@ -90,14 +155,13 @@ class HighlightControllerTest {
                 .build();
     }
 
-    */
-/**
+    /*
      * Mock HighlightSelectRequest
-     *//*
+     */
 
     private HighlightSelectRequest mockHighlightSelectRequest(List<UUID> uuids){
         return HighlightSelectRequest.builder()
                 .selectedHighlightIds(uuids)
                 .build();
     }
-}*/
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntityTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntityTest.java
@@ -1,0 +1,95 @@
+package com.midas.shootpointer.domain.highlight.entity;
+
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+class HighlightEntityTest {
+    @Test
+    @DisplayName("유저의 하이라이트 영상이 아닌 경우 IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID 예외를 반환합니다.")
+    void select_IS_NOT_USERS_HIGHLIGHT(){
+        //given
+        UUID memberId1=UUID.randomUUID();
+        UUID memberId2=UUID.randomUUID();
+
+        Member member1=Member.builder()
+                .email("test@naver.com")
+                .username("test")
+                .memberId(memberId1)
+                .build();
+        Member member2=Member.builder()
+                .email("test2@naver.com")
+                .username("test2")
+                .memberId(memberId2)
+                .build();
+
+        HighlightEntity highlight=HighlightEntity.builder()
+                .member(member1)
+                .highlightKey(UUID.randomUUID())
+                .highlightURL("url")
+                .build();
+
+        //when & then
+        assertThatThrownBy(() -> highlight.select(member2))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미 선택된 하이라이트인 경우 EXISTED_SELECTED 예외를 발생시킵니다.")
+    void select_EXIST_SELECTED(){
+        //given
+        UUID memberId=UUID.randomUUID();
+
+        Member member=Member.builder()
+                .email("test@naver.com")
+                .username("test")
+                .memberId(memberId)
+                .build();
+
+        HighlightEntity highlight=HighlightEntity.builder()
+                .member(member)
+                .highlightKey(UUID.randomUUID())
+                .highlightURL("url")
+                .isSelected(true)
+                .build();
+
+        //when & then
+        assertThatThrownBy(() -> highlight.select(member))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.EXISTED_SELECTED.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("select 메서드 실행 시 isSelected가 True로 변환됩니다.")
+    void select(){
+        //given
+        UUID memberId=UUID.randomUUID();
+
+        Member member=Member.builder()
+                .email("test@naver.com")
+                .username("test")
+                .memberId(memberId)
+                .build();
+
+        HighlightEntity highlight=HighlightEntity.builder()
+                .member(member)
+                .highlightKey(UUID.randomUUID())
+                .highlightURL("url")
+                .build();
+
+        //when
+        highlight.select(member);
+
+        //then
+        assertThat(highlight.getIsSelected()).isTrue();
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImplTest.java
@@ -1,0 +1,176 @@
+package com.midas.shootpointer.domain.highlight.helper;
+
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HighlightHelperImplTest {
+    @InjectMocks
+    private HighlightHelperImpl highlightHelper;
+
+    @Mock
+    private HighlightUtil highlightUtil;
+
+    @Mock
+    private HighlightValidator highlightValidator;
+
+
+    @Test
+    @DisplayName("highlightUtil.getDirectoryPath(String)이 실행되는지 검증합니다.")
+    void getDirectoryPath() {
+        //given
+        String key="key";
+
+        //when
+        highlightHelper.getDirectoryPath(key);
+
+        //then
+        verify(highlightUtil, times(1)).getDirectoryPath(key);
+    }
+
+    @Test
+    @DisplayName("highlightUtil.findHighlightByHighlightId(UUID)이 실행되는지 검증합니다.")
+    void findHighlightByHighlightId() {
+        //given
+        UUID highlightId=UUID.randomUUID();
+
+        //when
+        highlightHelper.findHighlightByHighlightId(highlightId);
+
+        //then
+        verify(highlightUtil,times(1)).findHighlightByHighlightId(highlightId);
+    }
+
+    @Test
+    @DisplayName("highlightUtil.savedAll(List<HighlightEntity>)이 실행되는지 확인합니다.")
+    void savedAll() {
+        //given
+        List<HighlightEntity> entities=new ArrayList<>();
+
+        //when
+        highlightHelper.savedAll(entities);
+
+        //then
+        verify(highlightUtil,times(1)).savedAll(entities);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.filesExist(String)이 실행되는지 검증합니다.")
+    void filesExist() {
+        //given
+        String dir="dir";
+
+        //when
+        highlightHelper.filesExist(dir);
+
+        //then
+        verify(highlightValidator,times(1)).filesExist(dir);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.isExistHighlightId(UUID)이 실행되는지 검증합니다.")
+    void isExistHighlightId() {
+        //given
+        UUID uuid=UUID.randomUUID();
+
+        //when
+        highlightHelper.isExistHighlightId(uuid);
+
+        //then
+        verify(highlightValidator,times(1)).isExistHighlightId(uuid);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.isValidMembersHighlight(UUID, UUID)이 실행되는지 검증합니다.")
+    void isValidMembersHighlight() {
+        //given
+        UUID highlightId=UUID.randomUUID();
+        UUID memberId=UUID.randomUUID();
+
+        //when
+        highlightHelper.isValidMembersHighlight(highlightId,memberId);
+
+        //then
+        verify(highlightValidator,times(1)).isValidMembersHighlight(highlightId,memberId);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.isValidMp4File(MultipartFile)이 실행되는지 검증합니다.")
+    void isValidMp4File() {
+        //given
+        MockMultipartFile mockMultipartFile =makeMockFile("test.mp4");
+
+        //when
+        highlightHelper.isValidMp4File(mockMultipartFile);
+
+        //then
+        verify(highlightValidator,times(1)).isValidMp4File(mockMultipartFile);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.isValidFileSize(MultipartFile)이 실행되는지 검증합니다.")
+    void isValidFileSize() {
+        //given
+        MockMultipartFile mockMultipartFile=makeMockFile("test.mp4");
+
+        //when
+        highlightHelper.isValidFileSize(mockMultipartFile);
+
+        //then
+        verify(highlightValidator,times(1)).isValidFileSize(mockMultipartFile);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.isExistDirectory(String)이 실행되는지 검증합니다.")
+    void isExistDirectory() {
+        //given
+        String dir="dir";
+
+        //when
+        highlightHelper.isExistDirectory(dir);
+
+        //then
+        verify(highlightValidator,times(1)).isExistDirectory(dir);
+    }
+
+    @Test
+    @DisplayName("highlightValidator.areValidFiles(List<MultipartFile>)이 실행되는지 검증합니다.")
+    void areValidFiles() {
+        //given
+        List<MultipartFile> list=List.of(
+                makeMockFile("test1.mp4"),
+                makeMockFile("test2.mp4"),
+                makeMockFile("test3.mp4")
+        );
+
+        //when
+        highlightHelper.areValidFiles(list);
+
+        //then
+        verify(highlightValidator,times(1)).areValidFiles(list);
+    }
+
+    private MockMultipartFile makeMockFile(String fileName){
+        byte[] bytes = new byte[10];
+        return new MockMultipartFile(
+                "file",
+                fileName,
+                "video/mp4",
+                bytes
+        );
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
@@ -1,20 +1,130 @@
+
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class HighlightUtilImplTest {
+    @InjectMocks
+    private HighlightUtilImpl highlightUtil;
+
+    @Mock
+    private HighlightQueryRepository queryRepository;
+
+    @Mock
+    private HighlightCommandRepository commandRepository;
+
+    @TempDir
+    Path tempDir;
 
     @Test
+    @DisplayName("존재하지 않는 디렉토리인 경우 새로 생성하고 경로를 반환합니다.")
     void getDirectoryPath() {
+        //given
+        highlightUtil=new HighlightUtilImpl(tempDir.toString(),queryRepository,commandRepository);
+        String highlightKey=UUID.randomUUID().toString();
+        Path expectedDir=tempDir.resolve(highlightKey);
+
+        //when
+        String result=highlightUtil.getDirectoryPath(highlightKey);
+
+        //then
+        assertThat(result).isEqualTo(expectedDir.toString());
+        assertThat(Files.exists(expectedDir)).isTrue();
     }
 
     @Test
+    @DisplayName("이미 존재하는 디렉토리인 경우 기존 경로를 반환합니다.")
+    void getDirectoryPath_existingDirectory() throws IOException {
+        //given
+        highlightUtil=new HighlightUtilImpl(tempDir.toString(),queryRepository,commandRepository);
+        String highlightKey=UUID.randomUUID().toString();
+        Path expectedDir=Files.createDirectories(tempDir.resolve(highlightKey));
+
+        //when
+        String result=highlightUtil.getDirectoryPath(highlightKey);
+
+        //then
+        assertThat(result).isEqualTo(expectedDir.toString());
+        assertThat(Files.exists(expectedDir)).isTrue();
+    }
+
+    @Test
+    @DisplayName("하이라이트 Id로 하이라이트 객체를 조회합니다.")
     void findHighlightByHighlightId() {
+        //given
+        UUID highlightKey=UUID.randomUUID();
+        UUID highlightId=UUID.randomUUID();
+
+        HighlightEntity highlight=makeHighlight(highlightKey,highlightId);
+        //when
+        when(queryRepository.findByHighlightId(highlightId)).thenReturn(Optional.of(highlight));
+        HighlightEntity result=highlightUtil.findHighlightByHighlightId(highlightId);
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getHighlightKey()).isEqualTo(highlightKey);
+        assertThat(result.getHighlightId()).isEqualTo(highlightId);
+    }
+
+    @Test
+    @DisplayName("하이라이트 Id로 하이라이트 객체를 조회시 존재하지 않으면 NOT_EXIST_HIGHLIGHT 예외가 발생합니다.")
+    void findHighlightByHighlightId_NOT_EXIST() {
+        //given
+        UUID highlightId=UUID.randomUUID();
+
+        //when
+        when(queryRepository.findByHighlightId(highlightId)).thenReturn(Optional.empty());
+
+        //then
+        assertThatThrownBy(()->highlightUtil.findHighlightByHighlightId(highlightId))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.NOT_EXIST_HIGHLIGHT.getMessage());
     }
 
     @Test
     void savedAll() {
+        //given
+        List<HighlightEntity> highlightEntities=List.of(
+                makeHighlight(UUID.randomUUID(),UUID.randomUUID()),
+                makeHighlight(UUID.randomUUID(),UUID.randomUUID())
+        );
+
+        //when
+        when(commandRepository.saveAll(highlightEntities)).thenReturn(highlightEntities);
+        highlightUtil.savedAll(highlightEntities);
+
+        //then
+        verify(commandRepository,times(1)).saveAll(highlightEntities);
+    }
+
+    private HighlightEntity makeHighlight(UUID highlightKey,UUID highlightId){
+        return HighlightEntity.builder()
+                .highlightURL("url")
+                .highlightKey(highlightKey)
+                .highlightId(highlightId)
+                .build();
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
@@ -1,0 +1,4 @@
+import static org.junit.jupiter.api.Assertions.*;
+class HighlightUtilImplTest {
+  
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
@@ -1,4 +1,20 @@
+package com.midas.shootpointer.domain.highlight.helper;
+
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.*;
+
 class HighlightUtilImplTest {
-  
+
+    @Test
+    void getDirectoryPath() {
+    }
+
+    @Test
+    void findHighlightByHighlightId() {
+    }
+
+    @Test
+    void savedAll() {
+    }
 }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
@@ -1,0 +1,173 @@
+package com.midas.shootpointer.domain.highlight.helper;
+
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HighlightValidatorImplTest {
+    @InjectMocks
+    private HighlightValidatorImpl highlightValidator;
+
+    @Mock
+    private HighlightQueryRepository highlightQueryRepository;
+
+
+    @Test
+    @DisplayName("디렉토리의 경로가 존재하면 true를 반환합니다.")
+    void filesExist_TRUE() throws IOException {
+        //given
+        Path tempDir = Files.createTempDirectory("test");
+        String dir = tempDir.toString();
+
+        //then
+        assertThat(highlightValidator.filesExist(dir)).isTrue();
+
+        //cleanup
+        Files.deleteIfExists(tempDir);
+    }
+
+    @Test
+    @DisplayName("디렉토리의 경로가 존재하지 않으면 false를 반환합니다.")
+    void filesExist_FALSE() throws IOException {
+        //given
+        String dir="dir";
+
+        //then
+        assertThat(highlightValidator.filesExist(dir)).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않은 하이라이트 객체를 조회시 NOT_EXIST_HIGHLIGHT 예외를 반환합니다.")
+    void isExistHighlightId() {
+        //given
+        UUID highlightId=UUID.randomUUID();
+
+        //when
+        CustomException exception=catchThrowableOfType(()->
+                highlightValidator.isExistHighlightId(highlightId),
+                CustomException.class
+        );
+
+        //then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_EXIST_HIGHLIGHT);
+
+    }
+
+    @Test
+    @DisplayName("유저의 하이라이트 영상이 아닌 경우 NOT_MATCH_HIGHLIGHT_VIDEO 예외를 반환합니다.")
+    void isValidMembersHighlight() {
+        //given
+        UUID memberId=UUID.randomUUID();
+        UUID highlightId=UUID.randomUUID();
+
+        //when
+        CustomException exception=catchThrowableOfType(()->
+                        highlightValidator.isValidMembersHighlight(highlightId,memberId),
+                CustomException.class
+        );
+
+        //then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_MATCH_HIGHLIGHT_VIDEO);
+    }
+
+    @Test
+    @DisplayName("파일의 타입이 video/mp4가 아니면 INVALID_FILE_TYPE를 반환합니다.")
+    void isValidMp4File() {
+        //given
+        MultipartFile file = new MockMultipartFile(
+                "file",
+                "video.mp3",
+                "video/mp3",
+                new byte[10]
+        );
+        //when
+        CustomException exception = catchThrowableOfType(
+                () -> highlightValidator.isValidMp4File(file),
+                CustomException.class
+        );
+
+        //then
+        assertThat(exception).isNotNull();
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_FILE_TYPE);
+
+    }
+
+    @Test
+    @DisplayName("파일의 크기가 MAX_FILE_SIZE 보다 큰 경우 FILE_SIZE_EXCEEDED 예외를 반환합니다.")
+    void isValidFileSize() {
+        //given
+        long size=600L * 1024L * 1024L;
+        byte[] content = new byte[(int) (10 * 1024)];
+        MultipartFile file = new MockMultipartFile("file", "test.mp4", "video/mp4", content);
+
+        MultipartFile spyFile = spy(file);
+        when(spyFile.getSize()).thenReturn(size);
+
+        //when & then
+        CustomException exception=catchThrowableOfType(()->
+                highlightValidator.isValidFileSize(spyFile),
+                CustomException.class
+        );
+        assertThat(exception).isNotNull();
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FILE_SIZE_EXCEEDED);
+
+    }
+
+    @Test
+    @DisplayName("존재하는 디렉토리인 경우 true를 반환합니다.")
+    void isExistDirectory_TRUE() throws IOException {
+        //given
+        Path tempPath=Files.createTempDirectory("test");
+
+        //when & then
+        assertThat(highlightValidator.filesExist(tempPath.toString())).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("디렉토리가 null 혹은 공백이면 false를 반환합니다.")
+    void isExistDirectory_null_or_blank_FALSE() throws IOException {
+        //given
+        String tempDir1=" ";
+        String tempDir2="";
+        String tempDir3=null;
+
+        //when & then
+        assertThat(highlightValidator.isExistDirectory(tempDir1)).isFalse();
+        assertThat(highlightValidator.isExistDirectory(tempDir2)).isFalse();
+        assertThat(highlightValidator.isExistDirectory(tempDir3)).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 디렉토리이면 false를 반환합니다.")
+    void isExistDirectory_NOT_EXIST_DIRECTORY_FALSE() throws IOException {
+        //given
+        String tempDir="not-exist";
+
+        //when & then
+        assertThat(highlightValidator.isExistDirectory(tempDir)).isFalse();
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
@@ -1,13 +1,12 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
-import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,20 +14,18 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class HighlightValidatorImplTest {
     @InjectMocks
+    @Spy
     private HighlightValidatorImpl highlightValidator;
-
-    @Mock
-    private HighlightQueryRepository highlightQueryRepository;
 
 
     @Test
@@ -169,5 +166,35 @@ class HighlightValidatorImplTest {
 
         //when & then
         assertThat(highlightValidator.isExistDirectory(tempDir)).isFalse();
+    }
+
+    @Test
+    @DisplayName("여러 파일들의 사이즈 유효성 검증과 mp4파일 유효성 검증을 실시합니다.")
+    void areValidFiles(){
+        //given
+        byte[] content = new byte[(int) (10 * 1024)];
+        MultipartFile file1 = new MockMultipartFile(
+                "file",
+                "test1.mp4",
+                "video/mp4",
+                content
+        );
+        MultipartFile file2 = new MockMultipartFile(
+                "file",
+                "test2.mp4",
+                "video/mp4",
+                content
+        );
+
+        List<MultipartFile> files=List.of(file1,file2);
+
+        //when
+        highlightValidator.areValidFiles(files);
+
+        //then
+        verify(highlightValidator,times(2))
+                .isValidFileSize(any(MultipartFile.class));
+        verify(highlightValidator,times(2))
+                .isValidMp4File(any(MultipartFile.class));
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImplTest.java
@@ -1,11 +1,13 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockMultipartFile;
@@ -26,6 +28,10 @@ class HighlightValidatorImplTest {
     @InjectMocks
     @Spy
     private HighlightValidatorImpl highlightValidator;
+
+
+    @Mock
+    private HighlightQueryRepository repository;
 
 
     @Test
@@ -60,6 +66,7 @@ class HighlightValidatorImplTest {
         UUID highlightId=UUID.randomUUID();
 
         //when
+        when(repository.existsByHighlightId(highlightId)).thenReturn(false);
         CustomException exception=catchThrowableOfType(()->
                 highlightValidator.isExistHighlightId(highlightId),
                 CustomException.class
@@ -79,6 +86,7 @@ class HighlightValidatorImplTest {
         UUID highlightId=UUID.randomUUID();
 
         //when
+        when(repository.isMembersHighlight(memberId,highlightId)).thenReturn(false);
         CustomException exception=catchThrowableOfType(()->
                         highlightValidator.isValidMembersHighlight(highlightId,memberId),
                 CustomException.class

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
@@ -1,0 +1,39 @@
+package com.midas.shootpointer.domain.highlight.mapper;
+
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HighlightFactoryTest {
+    private HighlightFactory factory=new HighlightFactory();
+
+    @Test
+    @DisplayName("List<fileName> 형태를 List<HighlightEntity> 형태로 매핑합니다.")
+    void createHighlightEntities(){
+        //given
+        List<String> fileNames=List.of(
+                "file1","file2","file3"
+        );
+        String highlightKey= UUID.randomUUID().toString();
+        UUID key=UUID.fromString(highlightKey);
+
+        //when
+        List<HighlightEntity> result=factory.createHighlightEntities(fileNames,highlightKey);
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getHighlightKey()).isEqualTo(key);
+        assertThat(result.get(1).getHighlightKey()).isEqualTo(key);
+        assertThat(result.get(2).getHighlightKey()).isEqualTo(key);
+
+        assertThat(result.get(0).getHighlightURL()).isEqualTo(fileNames.get(0));
+        assertThat(result.get(1).getHighlightURL()).isEqualTo(fileNames.get(1));
+        assertThat(result.get(2).getHighlightURL()).isEqualTo(fileNames.get(2));
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import com.midas.shootpointer.domain.member.entity.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -21,9 +22,13 @@ class HighlightFactoryTest {
         );
         String highlightKey= UUID.randomUUID().toString();
         UUID key=UUID.fromString(highlightKey);
+        Member member=Member.builder()
+                              .email("test@naver.com")
+                              .username("test")
+                              .build();
 
         //when
-        List<HighlightEntity> result=factory.createHighlightEntities(fileNames,highlightKey);
+        List<HighlightEntity> result=factory.createHighlightEntities(fileNames,highlightKey,member);
 
         //then
         assertThat(result).isNotEmpty();

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
@@ -1,0 +1,62 @@
+package com.midas.shootpointer.domain.highlight.mapper;
+
+import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
+import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HighlightMapperImplTest {
+
+    private final HighlightMapperImpl mapper=new HighlightMapperImpl();
+
+    @Test
+    @DisplayName("List<UUID> 형태를 HighlightSelectResponse 형태로 매핑합니다.")
+    void entityToResponse_LIST_UUIDS(){
+        //given
+        UUID uuid1=UUID.randomUUID();
+        UUID uuid2=UUID.randomUUID();
+        UUID uuid3=UUID.randomUUID();
+
+        List<UUID> uuids=List.of(uuid1,uuid2,uuid3);
+
+        //when
+        HighlightSelectResponse result=mapper.entityToResponse(uuids);
+
+        //then
+        assertThat(result.getSelectedHighlightIds().get(0)).isEqualTo(uuid1);
+        assertThat(result.getSelectedHighlightIds().get(1)).isEqualTo(uuid2);
+        assertThat(result.getSelectedHighlightIds().get(2)).isEqualTo(uuid3);
+    }
+
+    @Test
+    @DisplayName("HighlightEntity 형태를 HighlightSelectResponse 형태로 매핑합니다.")
+    void entityToResponse_ENTITY(){
+        //given
+        UUID highlightId=UUID.randomUUID();
+        UUID highlightKey=UUID.randomUUID();
+        LocalDateTime time=LocalDateTime.now();
+
+        HighlightEntity entity=HighlightEntity.builder()
+                .highlightId(highlightId)
+                .highlightKey(highlightKey)
+                .highlightURL("url")
+                .build();
+        entity.setCreatedAt(time);
+
+        //when
+        HighlightResponse result=mapper.entityToResponse(entity);
+
+        //then
+        assertThat(result.getCreatedAt()).isEqualTo(entity.getCreatedAt());
+        assertThat(result.getHighlightId()).isEqualTo(entity.getHighlightId());
+        assertThat(result.getHighlightIdentifier()).isEqualTo(entity.getHighlightKey());
+        assertThat(result.getHighlightUrl()).isEqualTo(entity.getHighlightURL());
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/service/HighlightStorageServiceTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/service/HighlightStorageServiceTest.java
@@ -1,0 +1,78 @@
+package com.midas.shootpointer.domain.highlight.service;
+
+import com.midas.shootpointer.domain.highlight.helper.HighlightHelper;
+import com.midas.shootpointer.global.common.ErrorCode;
+import com.midas.shootpointer.global.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HighlightStorageServiceTest {
+
+    @InjectMocks
+    private HighlightStorageService storageService;
+
+    @Mock
+    private HighlightHelper highlightHelper;
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    @DisplayName("파일이 지정된 디렉토리에 저장되고 저장된 파일 이름이 반환됩니다.")
+    void storeHighlights_SUCCESS() throws IOException {
+        //given
+        String highlightKey= UUID.randomUUID().toString();
+        Path dirPath=tempDir.resolve(highlightKey);
+        Files.createDirectories(dirPath);
+
+        when(highlightHelper.getDirectoryPath(highlightKey))
+                .thenReturn(dirPath.toString());
+        byte[] fileContent="video".getBytes();
+        MultipartFile file1=new MockMultipartFile("file1","video1.mp4","video/mp4",fileContent);
+        MultipartFile file2=new MockMultipartFile("file2","video2.mp4","video/mp4",fileContent);
+        List<MultipartFile> files=List.of(file1,file2);
+
+        //when
+        List<String> result=storageService.storeHighlights(files,highlightKey);
+
+        //then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).endsWith(".mp4");
+        assertThat(Files.list(dirPath).count()).isEqualTo(2);
+
+        verify(highlightHelper).getDirectoryPath(highlightKey);
+    }
+    @Test
+    @DisplayName("파일 저장 중 IOException이 발생하면 FILE_UPLOAD_FAILED을 반환합니다.")
+    void storeHighlights_failToSaveFile() throws Exception {
+        // given
+        String highlightKey = "testKey";
+        when(highlightHelper.getDirectoryPath(highlightKey)).thenReturn("/invalid/path"); // 존재하지 않는 경로
+
+        MultipartFile badFile = new MockMultipartFile("file", "bad.mp4", "video/mp4", new byte[1]);
+
+        // when & then
+        assertThatThrownBy(() -> storageService.storeHighlights(List.of(badFile), highlightKey))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.FILE_UPLOAD_FAILED.getMessage());
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
@@ -6,10 +6,12 @@ import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.repository.MemberCommandRepository;
 import com.midas.shootpointer.domain.post.entity.HashTag;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
+import com.midas.shootpointer.global.config.JpaAuditingConfig;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.temporal.ChronoUnit;
@@ -19,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("dev")
+@Import(JpaAuditingConfig.class)
 class PostQueryRepositoryTest {
     @Autowired
     private PostQueryRepository postQueryRepository;


### PR DESCRIPTION
## 🍀 이슈 번호

- #131 

---

## 🎯작업개요

> 기존 `HighlightService` 클래스가 파일 검증, 엔티티 변환, 저장 로직 등 다양한 역할을 동시에 수행하고 있어
`SRP(단일 책임 원칙)`가 지켜지지 않은 문제.
이에 따라 검증, 변환, 저장 책임을 각각의 클래스로 분리하여 계층 간 책임을 명확히 했습니다.

## ✅ 작업 사항

- #132 


- 기존 `HighlightService`에 유효성 검증에 대한 로직이 존재하여 `검증 책임`이 분할되지 않은점을 `HighlightValidator`를 통해 검증 책임을 분할했습니다.

```java
public interface HighlightValidator {
    boolean filesExist(String directory);
    void isExistHighlightId(UUID highlightId);
    void isValidMembersHighlight(UUID highlightId,UUID memberId);
    void isValidMp4File(MultipartFile file);
    void isValidFileSize(MultipartFile file);
    boolean isExistDirectory(String directory);
    void areValidFiles(List<MultipartFile> files);
}

```

---

- #133 

- 아래와 같은 `mapper` 메서드 구현으로 기존 `service` 계층에서 DTO변환을 담당하는 책임을 `Mapper class`로 분할했습니다.
1. 선택된 `하이라이트 id 목록`을 `하이라이트 목록 선택 응답 DTO`로 변환하는 매핑 메서드
2. `하이라이트 엔티티`를 `하이라이트 응답 DTO`로 변환하는 매핑 메서드

> 추가로` file 이름 목록`과 `하이라이트 고유 키 값 -> 하이라이트 엔티티 리스트`로 매핑하는 `단일 Dto `혹은 `단일 엔티티`에 대한 매핑이 아닌 복합적인 값을 토대로 매핑을 수행하는 함수에 대해서는 `HighlightFactory`를 통해 구현했습니다.  #129 에서는 `inner class`에 `factory class`를 구현했는데 이 때, `Default` 접근자로서 `PostListResponseFactory` 메서드를 실행합니다. 따라서, 이와 같은 방법은 캡슐화를 저해한다고 생각하여 따로 클래스를 두어 구현했습니다.
추후, 수정 과정에서 `PostListResponseFactory` 또한 분리하여 리팩토링 예정입니다.
---

- #134  

1. `HighlightManager`를 두어 비즈니스 규칙의 중심 허브를 구축했습니다.
2. `HighlightManager`에서는 단위 테스트가 아닌 `@SpringbootTest`를 통해 통합테스트를 진행하여 전체 로직의 전체적인 흐름 테스트를 진행했습니다.




---

## ⌨ 기타
