### PR TITLE
🌟 Feature : 마이페이지 사용자 게시물 조회 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ jacocoTestReport{
 		classDirectories.setFrom(
 				files(classDirectories.files.collect{
 					fileTree(dir: it, exclude: [
-					        "**/global/config/**",
+							"**/global/config/**",
 							"**/global/exception/**",
 							"**/global/dto/**",
 							"**/global/aop/**",

--- a/src/main/java/com/midas/shootpointer/domain/post/business/PostManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/PostManager.java
@@ -233,6 +233,24 @@ public class PostManager {
 
         return factory.build(postByHashTagByElasticSearch);
     }
+    
+    @Transactional(readOnly = true)
+    public PostListResponse getMyPosts(UUID memberId) {
+        List<Long> postIds = postHelper.findPostIdsByMemberId(memberId);
+
+        if (postIds.isEmpty()) {
+            return PostListResponse.of(null, Collections.emptyList());
+        }
+
+        List<PostEntity> postEntities = postHelper.findPostsByPostIds(postIds);
+        List<PostResponse> postResponses = postEntities.stream()
+            .map(postMapper::entityToDto)
+            .toList();
+        
+        Long lastPostId = postEntities.isEmpty() ? null : postEntities.get(postEntities.size() - 1).getPostId();
+        
+        return PostListResponse.of(lastPostId, postResponses);
+    }
 
     /**
      * List<PostSearchHit> -> PostListResponse 변환 inner class

--- a/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryService.java
@@ -6,6 +6,7 @@ import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PostQueryService {
     PostResponse singleRead(Long decode);
@@ -17,4 +18,6 @@ public interface PostQueryService {
     PostListResponse searchByElastic(String search, int size,PostSort sort);
 
     List<SearchAutoCompleteResponse> suggest(String keyword);
+    
+    PostListResponse getMyPosts(UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.midas.shootpointer.domain.post.dto.response.PostListResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,5 +40,10 @@ public class PostQueryServiceImpl implements PostQueryService{
     @Override
     public List<SearchAutoCompleteResponse> suggest(String keyword) {
         return postManager.suggest(keyword);
+    }
+    
+    @Override
+    public PostListResponse getMyPosts(UUID memberId) {
+        return postManager.getMyPosts(memberId);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/controller/PostQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/controller/PostQueryController.java
@@ -1,11 +1,13 @@
 package com.midas.shootpointer.domain.post.controller;
 
+import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.post.business.query.PostQueryService;
 import com.midas.shootpointer.domain.post.dto.response.PostListResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
 import com.midas.shootpointer.global.dto.ApiResponse;
+import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -175,5 +177,10 @@ public class PostQueryController {
     public ResponseEntity<ApiResponse<List<SearchAutoCompleteResponse>>> searchSuggest(@RequestParam(value = "keyword",required = true) String keyword){
         return ResponseEntity.ok(ApiResponse.ok(postQueryService.suggest(keyword)));
     }
-
+    
+    @GetMapping("/mypage")
+    public ResponseEntity<ApiResponse<PostListResponse>> getMyPosts() {
+        Member member = SecurityUtils.getCurrentMember();
+        return ResponseEntity.ok(ApiResponse.ok(postQueryService.getMyPosts(member.getMemberId())));
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelper.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelper.java
@@ -1,4 +1,10 @@
 package com.midas.shootpointer.domain.post.helper.simple;
 
+import com.midas.shootpointer.domain.post.entity.PostEntity;
+import java.util.List;
+import java.util.UUID;
+
 public interface PostHelper extends PostValidation, PostUtil {
+	List<Long> findPostIdsByMemberId(UUID memberId);
+	List<PostEntity> findPostsByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelperImpl.java
@@ -83,5 +83,15 @@ public class PostHelperImpl implements PostHelper{
     public List<PostEntity> getPopularPostListBySliceAndNoOffset(Long postId, int size) {
         return postUtil.getPopularPostListBySliceAndNoOffset(postId,size);
     }
+    
+    @Override
+    public List<Long> findPostIdsByMemberId(UUID memberId) {
+        return postUtil.findPostIdsByMemberId(memberId);
+    }
+    
+    @Override
+    public List<PostEntity> findPostsByPostIds(List<Long> postIds) {
+        return postUtil.findPostsByPostIds(postIds);
+    }
 
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtil.java
@@ -5,6 +5,7 @@ import com.midas.shootpointer.domain.post.business.PostOrderType;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface PostUtil {
     PostEntity findPostByPostId(Long postId);
@@ -15,4 +16,6 @@ public interface PostUtil {
     List<PostEntity> getPopularPostListBySliceAndNoOffset(Long postId,int size);
     PostOrderType isValidAndGetPostOrderType(String type);
     List<PostEntity> getPostEntitiesByPostTitleOrPostContent(String search,Long postId,int size);
+    List<Long> findPostIdsByMemberId(UUID memberId);
+    List<PostEntity> findPostsByPostIds(List<Long> postIds);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtilImpl.java
@@ -7,6 +7,7 @@ import com.midas.shootpointer.domain.post.repository.PostCommandRepository;
 import com.midas.shootpointer.domain.post.repository.PostQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -84,5 +85,14 @@ public class PostUtilImpl implements PostUtil{
     public List<PostEntity> getPostEntitiesByPostTitleOrPostContent(String search,Long postId,int size) {
         return postQueryRepository.getPostEntitiesByPostTitleOrPostContentOrderByCreatedAtDesc(search,size,postId);
     }
-
+    
+    @Override
+    public List<Long> findPostIdsByMemberId(UUID memberId) {
+        return postQueryRepository.findPostIdsByMemberId(memberId);
+    }
+    
+    @Override
+    public List<PostEntity> findPostsByPostIds(List<Long> postIds) {
+        return postQueryRepository.findPostsByPostIds(postIds);
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.domain.post.repository;
 
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 import jakarta.persistence.LockModeType;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -63,4 +64,20 @@ public interface PostQueryRepository extends JpaRepository<PostEntity,Long>{
 
     @Query(value = "SELECT p FROM PostEntity p JOIN FETCH p.member m JOIN FETCH p.highlight h")
     List<PostEntity> findAllWithMemberAndHighlight();
+    
+    /**
+     * 회원이 작성한 모든 게시물 ID 조회
+     */
+    @Query(value = "SELECT p.post_id FROM post AS p " +
+        "WHERE p.member_id = :memberId " +
+        "ORDER BY p.post_id DESC",
+        nativeQuery = true)
+    List<Long> findPostIdsByMemberId(@Param(value = "memberId") UUID memberId);
+    
+    @Query(value = "SELECT p FROM PostEntity p " +
+        "JOIN FETCH p.member m " +
+        "JOIN FETCH p.highlight h " +
+        "WHERE p.postId IN :postIds " +
+        "ORDER BY p.postId DESC")
+    List<PostEntity> findPostsByPostIds(@Param(value = "postIds") List<Long> postIds);
 }

--- a/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
@@ -8,6 +8,7 @@ import com.midas.shootpointer.domain.post.repository.PostElasticSearchRepository
 import com.midas.shootpointer.domain.post.mapper.PostElasticSearchMapper;
 import com.midas.shootpointer.domain.post.entity.HashTag;
 import com.midas.shootpointer.domain.post.repository.PostQueryRepository;
+import com.midas.shootpointer.global.util.jwt.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -29,9 +30,9 @@ public class DummyDataLoader implements CommandLineRunner {
     private final MakeRandomWord makeRandomWord;
     private final MemberCommandRepository memberRepository;
     private final HighlightCommandRepository highlightCommandRepository;
-    private final PostElasticSearchRepository postElasticSearchRepository;
-    private final PostElasticSearchMapper mapper;
-
+//    private final PostElasticSearchRepository postElasticSearchRepository;
+//    private final PostElasticSearchMapper mapper;
+    private final JwtUtil jwtUtil;
     private final int batchSize=1_000;
     private final int insertSize=1_000;
     private final PostQueryRepository postQueryRepository;
@@ -94,6 +95,8 @@ public class DummyDataLoader implements CommandLineRunner {
         if (!batchArgs.isEmpty()){
             jdbcTemplate.batchUpdate(sql,batchArgs);
         }
+        
+        System.out.println("Access Token : " + jwtUtil.createToken(memberId, member.getEmail(), member.getUsername()));
 
         /**
          * Elastic Search 배치 처리

--- a/src/main/resources/application-testdata.yml
+++ b/src/main/resources/application-testdata.yml
@@ -1,0 +1,132 @@
+server:
+  port: ${SERVER_PORT:9000}
+
+encrypt:
+  key: dafd6bef1f363a1ba1a32623aa8f0b8741b0736e11b898febaceb58b7bcedcf8
+
+# -------------------------
+# [JWT Settings]
+# -------------------------
+
+jwt:
+  secret: 4qmZKqt8Kwd2MCbGj39akXECPZr9hPUlgxYq2L6e9ho=
+  access_expiration_time: 86400000
+  refresh_expiration_time: 259200000
+
+
+spring:
+  elasticsearch:
+    enabled: false
+
+  main:
+    allow-bean-definition-overriding: true
+  application:
+    name: shootpointer
+  # Data 크기
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 5000MB
+      max-request-size: 5000MB
+
+
+  # 데이터소스 설정
+  datasource:
+    url: jdbc:postgresql://localhost:5432/shootpointer
+    username: timer973
+    password: wotjd9024@
+    driver-class-name: org.postgresql.Driver
+
+    hikari:
+      maximum-pool-size: 50
+      minimum-idle: 10
+      connection-timeout: 30000
+
+  # JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        format_sql: true
+        use_sql_comments: true
+        show-sql: true
+
+  # MongoDB 설정
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/shootpointer
+
+    # Redis 설정
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 2000ms
+      jedis:
+        pool:
+          max-active: 8
+          max-idle: 8
+          min-idle: 0
+  # kakao
+  security:
+    oauth2:
+      client:
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kauth.kakao.com/v2/user/me
+            user-name-attribute: id
+        registration:
+          kakao:
+            client-id: test
+            client-secret: test
+            redirect-uri: http://localhost:8081
+            authorization-grant-type: authorization_code
+            client-authentication-method: POST
+            client-name: Kakao
+            scope:
+              - profile_nickname
+              - account_email
+
+# 로깅 설정
+logging:
+  level:
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.data.mongodb: DEBUG
+    redis.clients.jedis: DEBUG
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
+
+# Actuator 설정 (헬스체크용)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: always
+
+#Kakao
+kakao:
+  auth:
+    uri: https://kauth.kakao.com
+  api:
+    uri: https://kapi.kakao.com
+
+opencv:
+  url: http://localhost:8888
+  api:
+    post:
+      send-image: /api/send-img
+    get:
+      fetch-video: /api/fetch-video
+    proxy:
+      upload-video: upload
+
+video:
+  path: /home/ubuntu/shoot-pointer/videos

--- a/src/test/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImplTest.java
@@ -6,6 +6,7 @@ import com.midas.shootpointer.domain.post.dto.response.PostResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
 import com.midas.shootpointer.domain.post.entity.HashTag;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -108,6 +109,21 @@ class PostQueryServiceImplTest {
         //then
         verify(postManager,times(1)).suggest(keyword);
     }
+    
+    @Test
+    @DisplayName("마이페이지 조회 시 postManager - getMyPosts(memberId)의 호출을 확인합니다.")
+    void getMyPosts(){
+        //given
+        UUID memberId = UUID.randomUUID();
+        
+        //when
+        when(postManager.getMyPosts(memberId)).thenReturn(postListResponse);
+        postQueryService.getMyPosts(memberId);
+        
+        //then
+        verify(postManager, times(1)).getMyPosts(memberId);
+    }
+    
     private PostResponse makePostResponse(LocalDateTime time,Long postId){
         return PostResponse.builder()
                 .content("content")

--- a/src/test/java/com/midas/shootpointer/domain/post/entity/PostEntityTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/entity/PostEntityTest.java
@@ -4,7 +4,6 @@ import com.midas.shootpointer.domain.backnumber.entity.BackNumber;
 import com.midas.shootpointer.domain.backnumber.entity.BackNumberEntity;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import org.assertj.core.api.Assertions;
-import org.junit.Before;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/com/midas/shootpointer/domain/post/helper/PostHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/helper/PostHelperImplTest.java
@@ -6,6 +6,7 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.simple.PostHelperImpl;
 import com.midas.shootpointer.domain.post.helper.simple.PostUtil;
 import com.midas.shootpointer.domain.post.helper.simple.PostValidation;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class PostHelperImplTest {
@@ -216,5 +218,38 @@ class PostHelperImplTest {
 
         //then
         verify(postUtil,times(1)).isValidAndGetPostOrderType(type);
+    }
+    
+    @Test
+    @DisplayName("memberId로 게시물 ID 목록을 조회합니다 - postUtil.findPostIdsByMemberId(memberId) 메서드가 실행되는지 확인합니다.")
+    void findPostIdsByMemberId() {
+        //given
+        UUID memberId = UUID.randomUUID();
+        List<Long> expectedPostIds = List.of(1L, 2L, 3L);
+        when(postUtil.findPostIdsByMemberId(memberId)).thenReturn(expectedPostIds);
+        
+        //when
+        List<Long> result = postHelper.findPostIdsByMemberId(memberId);
+        
+        //then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly(1L, 2L, 3L);
+        verify(postUtil, times(1)).findPostIdsByMemberId(memberId);
+    }
+    
+    @Test
+    @DisplayName("게시물 ID 목록으로 게시물 엔티티들을 조회합니다 - postUtil.findPostsByPostIds(postIds) 메서드가 실행되는지 확인합니다.")
+    void findPostsByPostIds() {
+        //given
+        List<Long> postIds = List.of(1L, 2L, 3L);
+        List<PostEntity> expectedPosts = List.of(postEntity, newPostEntity, postEntity);
+        when(postUtil.findPostsByPostIds(postIds)).thenReturn(expectedPosts);
+        
+        //when
+        List<PostEntity> result = postHelper.findPostsByPostIds(postIds);
+        
+        //then
+        assertThat(result).hasSize(3);
+        verify(postUtil, times(1)).findPostsByPostIds(postIds);
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTestOnlyQuery.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTestOnlyQuery.java
@@ -78,8 +78,50 @@ public class PostUtilImplTestOnlyQuery {
         assertThat(result).hasSize(10);
         verify(postQueryRepository, times(1)).getPopularPostListBySliceAndNoOffset(anyInt(), anyLong());
     }
-
-
+    
+    @DisplayName("memberId로 게시물 ID 목록을 조회합니다. - postQueryRepository.findPostIdsByMemberId() 동작 유무를 확인합니다.")
+    @Test
+    void findPostIdsByMemberId() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        List<Long> expectedPostIds = List.of(1L, 2L, 3L);
+        
+        when(postQueryRepository.findPostIdsByMemberId(memberId))
+            .thenReturn(expectedPostIds);
+        
+        // when
+        List<Long> result = postUtil.findPostIdsByMemberId(memberId);
+        
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result).containsExactly(1L, 2L, 3L);
+        verify(postQueryRepository, times(1)).findPostIdsByMemberId(memberId);
+    }
+    
+    @DisplayName("게시물 ID 목록으로 게시물 엔티티들을 조회합니다. - postQueryRepository.findPostsByPostIds() 동작 유무를 확인합니다.")
+    @Test
+    void findPostsByPostIds() {
+        // given
+        List<Long> postIds = List.of(1L, 2L, 3L);
+        Member mockMember = makeMember();
+        HighlightEntity mockHighlight = makeHighlight(mockMember);
+        
+        List<PostEntity> expectedPosts = List.of(
+            makeMockPost(mockMember, mockHighlight),
+            makeMockPost(mockMember, mockHighlight),
+            makeMockPost(mockMember, mockHighlight)
+        );
+        
+        when(postQueryRepository.findPostsByPostIds(postIds))
+            .thenReturn(expectedPosts);
+        
+        // when
+        List<PostEntity> result = postUtil.findPostsByPostIds(postIds);
+        
+        // then
+        assertThat(result).hasSize(3);
+        verify(postQueryRepository, times(1)).findPostsByPostIds(postIds);
+    }
 
     private PostEntity makeMockPost(Member member, HighlightEntity highlight) {
         return PostEntity.builder()


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #136 

---

## ✅ 작업 사항

➡️ 기존에 있던 `PostListResponse`를 활용하여 게시물 내역 조회에 활용합니다.

➡️ `memberId`를 기준으로 사용자가 작성한 게시물들을 모두 조회합니다.

➡️ `JOIN FETCH` 사용하여 **PostEntity**와 연관된 Entity를 즉시 로딩(Eager Loading)하는 전략을 채택하였습니다.
> 이를 통해 N + 1 Problem, 쿼리 성능 최적화 (3 to 1) 등 다양한 문제를 해결함.

---

## ⌨ 기타
