### PR TITLE
🌟Feature : 유저별 하이라이트 영상 리스트 조회

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -1,9 +1,6 @@
 package com.midas.shootpointer.domain.highlight.business;
 
-import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.highlight.dto.*;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import com.midas.shootpointer.domain.highlight.helper.HighlightHelper;
 import com.midas.shootpointer.domain.highlight.mapper.HighlightFactory;
@@ -14,6 +11,9 @@ import com.midas.shootpointer.domain.member.helper.MemberHelper;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -104,5 +104,22 @@ public class HighlightManager {
         return savedEntities.stream()
                 .map(mapper::entityToResponse)
                 .toList();
+    }
+
+    public Page<HighlightInfoResponse> listByPaging(int page, int size,UUID memberId) {
+        /**
+         * 1. Paging 처리
+         */
+        Pageable paging= PageRequest.of(page,size);
+
+        /**
+         * 2. member의 모든 하이라이트 리스트 조회
+         */
+        Page<HighlightEntity> highlightEntityList=highlightHelper.fetchMembersHighlights(memberId,paging);
+
+        /**
+         * 3. mapping
+         */
+        return highlightEntityList.map(mapper::infoResponseToEntity);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightCommandController.java
@@ -1,6 +1,6 @@
 package com.midas.shootpointer.domain.highlight.controller;
 
-import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
@@ -19,8 +19,8 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/highlight")
 @RequiredArgsConstructor
-public class HighlightController {
-    private final HighlightCommandService highlightCommandService;
+public class HighlightCommandController {
+    private final HighlightManager manager;
 
     @PostMapping("/select")
     public ResponseEntity<ApiResponse<HighlightSelectResponse>> selectHighlight(
@@ -28,7 +28,7 @@ public class HighlightController {
     ) {
         Member member = SecurityUtils.getCurrentMember();
 
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.selectHighlight(request, member)));
+        return ResponseEntity.ok(ApiResponse.ok(manager.selectHighlight(request, member)));
     }
 
     @PostMapping("/upload-result")
@@ -37,6 +37,6 @@ public class HighlightController {
             @RequestPart(value = "uploadHighlightDto") UploadHighlight request,
             @RequestPart(value = "highlights") List<MultipartFile> highlights
     ) {
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.uploadHighlights(request,highlights,memberId)));
+        return ResponseEntity.ok(ApiResponse.ok(manager.uploadHighlights(request,highlights,memberId)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @RequestMapping("/api/highlight")
 public class HighlightQueryController {
-    private HighlightManager manager;
+    private final HighlightManager manager;
 
     @GetMapping("/list")
     public ResponseEntity<ApiResponse<Page<HighlightInfoResponse>>> highlightList(

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -1,12 +1,31 @@
 package com.midas.shootpointer.domain.highlight.controller;
 
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
+import com.midas.shootpointer.global.dto.ApiResponse;
+import com.midas.shootpointer.global.security.SecurityUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/highlight")
 public class HighlightQueryController {
-    private HighlightQue
+    private HighlightManager manager;
+
+    @GetMapping("/list")
+    public ResponseEntity<ApiResponse<Page<HighlightInfoResponse>>> highlightList(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ){
+        UUID memberId= SecurityUtils.getCurrentMemberId();
+        return ResponseEntity.ok(ApiResponse.ok( manager.listByPaging(page,size,memberId)));
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -1,0 +1,12 @@
+package com.midas.shootpointer.domain.highlight.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/highlight")
+public class HighlightQueryController {
+    private HighlightQue
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightInfoResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightInfoResponse.java
@@ -1,0 +1,18 @@
+package com.midas.shootpointer.domain.highlight.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Builder
+public record HighlightInfoResponse(
+        UUID highlightId,
+        LocalDateTime createdDate,
+        Integer totalTwoPoint,
+        Integer totalThreePoint
+) {
+    public static HighlightInfoResponse of(UUID highlightId, LocalDateTime createdDate, Integer totalTwoPoint, Integer totalThreePoint){
+        return new HighlightInfoResponse(highlightId,createdDate,totalTwoPoint,totalThreePoint);
+    }
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightInfoResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightInfoResponse.java
@@ -10,9 +10,10 @@ public record HighlightInfoResponse(
         UUID highlightId,
         LocalDateTime createdDate,
         Integer totalTwoPoint,
-        Integer totalThreePoint
+        Integer totalThreePoint,
+        String highlightUrl
 ) {
-    public static HighlightInfoResponse of(UUID highlightId, LocalDateTime createdDate, Integer totalTwoPoint, Integer totalThreePoint){
-        return new HighlightInfoResponse(highlightId,createdDate,totalTwoPoint,totalThreePoint);
+    public static HighlightInfoResponse of(UUID highlightId, LocalDateTime createdDate, Integer totalTwoPoint, Integer totalThreePoint,String highlightUrl){
+        return new HighlightInfoResponse(highlightId,createdDate,totalTwoPoint,totalThreePoint,highlightUrl);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -2,6 +2,8 @@ package com.midas.shootpointer.domain.highlight.helper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,6 +28,11 @@ public class HighlightHelperImpl implements HighlightHelper{
     @Override
     public List<HighlightEntity> savedAll(List<HighlightEntity> entities) {
         return highlightUtil.savedAll(entities);
+    }
+
+    @Override
+    public Page<HighlightEntity> fetchMembersHighlights(UUID memberId, Pageable pageable) {
+        return highlightUtil.fetchMembersHighlights(memberId,pageable);
     }
 
     @Override

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -1,6 +1,8 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.UUID;
@@ -9,4 +11,5 @@ public interface HighlightUtil {
     String getDirectoryPath(String highlightKey);
     HighlightEntity findHighlightByHighlightId(UUID highlightId);
     List<HighlightEntity> savedAll(List<HighlightEntity> entities);
+    Page<HighlightEntity> fetchMembersHighlights(UUID memberId, Pageable pageable);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -7,6 +7,8 @@ import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -56,6 +58,11 @@ public class HighlightUtilImpl implements HighlightUtil{
     @Override
     public List<HighlightEntity> savedAll(List<HighlightEntity> entities) {
         return highlightCommandRepository.saveAll(entities);
+    }
+
+    @Override
+    public Page<HighlightEntity> fetchMembersHighlights(UUID memberId, Pageable pageable) {
+        return highlightQueryRepository.fetchAllMembersHighlights(memberId, pageable);
     }
 
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
@@ -10,4 +11,5 @@ import java.util.UUID;
 public interface HighlightMapper {
     HighlightSelectResponse entityToResponse(List<UUID> selectedHighlights);
     HighlightResponse entityToResponse(HighlightEntity highlight);
+    HighlightInfoResponse infoResponseToEntity(HighlightEntity entity);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -31,7 +31,7 @@ public class HighlightMapperImpl implements HighlightMapper{
 
     @Override
     public HighlightInfoResponse infoResponseToEntity(HighlightEntity entity) {
-        return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.getThreePointCount());
+        return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.totalThreePoint());
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -31,7 +31,7 @@ public class HighlightMapperImpl implements HighlightMapper{
 
     @Override
     public HighlightInfoResponse infoResponseToEntity(HighlightEntity entity) {
-        return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.totalThreePoint());
+        return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.totalThreePoint(),entity.getHighlightURL());
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
@@ -26,6 +27,11 @@ public class HighlightMapperImpl implements HighlightMapper{
                 .highlightIdentifier(highlight.getHighlightKey())
                 .highlightUrl(highlight.getHighlightURL())
                 .build();
+    }
+
+    @Override
+    public HighlightInfoResponse infoResponseToEntity(HighlightEntity entity) {
+        return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.getThreePointCount());
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -1,11 +1,14 @@
 package com.midas.shootpointer.domain.highlight.repository;
 
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 @Repository
@@ -24,4 +27,16 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
     boolean existsByHighlightIdAndMember(@Param("highlightId") UUID highlightId, @Param("memberId") UUID memberId);
 
     boolean existsByHighlightId(UUID highlightId);
+
+    @Query(value = """
+            SELECT HighlightEntity
+            FROM HighlightEntity as h
+            INNER JOIN
+            Member as m
+            WHERE m.isAggregationAgreed = :true
+              AND h.isSelected =:true
+              AND m.memberId =:memberId
+            ORDER BY h.createdAt DESC
+        """)
+    Page<HighlightEntity> fetchAllMembersHighlights(@Param("memberId")UUID memberId, Pageable pageable);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -29,12 +29,12 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
     boolean existsByHighlightId(UUID highlightId);
 
     @Query(value = """
-            SELECT HighlightEntity
+            SELECT h
             FROM HighlightEntity as h
             INNER JOIN
-            Member as m
-            WHERE m.isAggregationAgreed = :true
-              AND h.isSelected =:true
+            Member as m ON h.member.memberId = m.memberId
+            WHERE m.isAggregationAgreed = true
+              AND h.isSelected = true
               AND m.memberId =:memberId
             ORDER BY h.createdAt DESC
         """)

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
@@ -1,9 +1,6 @@
 package com.midas.shootpointer.domain.highlight.business;
 
-import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.highlight.dto.UploadHighlight;
+import com.midas.shootpointer.domain.highlight.dto.*;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
 import com.midas.shootpointer.domain.member.entity.Member;
@@ -14,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -43,6 +41,9 @@ class HighlightManagerTest  {
 
     @Autowired
     private MemberCommandRepository memberCommandRepository;
+
+    @Autowired
+    private HighlightCommandRepository highlightCommandRepository;
 
     @TempDir
     private static Path tempDir;
@@ -141,6 +142,40 @@ class HighlightManagerTest  {
         List<HighlightEntity> saved = repository.findAll();
         assertThat(saved).hasSize(2);
         assertThat(saved.get(0).getHighlightKey()).isEqualTo(highlightKey);
+    }
+
+
+    @Test
+    @DisplayName("회원별 하이라이트 페이징 조회를 실시합니다.")
+    void listByPagingHighlights(){
+        // given
+        Member member = memberCommandRepository.save(Member.builder()
+                .email("test@naver.com")
+                .username("tester")
+                .isAggregationAgreed(true)
+                .build());
+
+        // DB에 10개의 하이라이트 데이터 저장
+        for (int i = 1; i <= 10; i++) {
+            HighlightEntity entity=HighlightEntity.builder()
+                    .highlightKey(UUID.randomUUID())
+                    .highlightURL("https://cdn.example.com/video" + i + ".mp4")
+                    .isSelected(true)
+                    .member(member)
+                    .build();
+            entity.setCreatedAt(LocalDateTime.now().minusDays(i));
+
+            highlightCommandRepository.save(entity);
+        }
+
+        // when
+        Page<HighlightInfoResponse> result = highlightManager.listByPaging(0, 5, member.getMemberId());
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(5); // 첫 페이지 5개
+        assertThat(result.getTotalElements()).isEqualTo(10); // 전체 10개
+        assertThat(result.getContent().getFirst().highlightUrl()).contains(".mp4");
     }
     private HighlightEntity makeHighlightEntity(String url,UUID highlightKey,Member member){
         return HighlightEntity.builder()

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
@@ -74,7 +74,7 @@ class HighlightCommandControllerTest  {
                 )))
                 .andDo(print());
 
-        verify(highlightCommandService).selectHighlight(any(HighlightSelectRequest.class),any(Member.class));
+        verify(manager).selectHighlight(any(HighlightSelectRequest.class),any(Member.class));
     }
 
 

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
@@ -2,7 +2,7 @@ package com.midas.shootpointer.domain.highlight.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.midas.shootpointer.WithMockCustomMember;
-import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
@@ -34,7 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringBootTest
 @ActiveProfiles("test")
 @WithMockCustomMember
-class HighlightControllerTest  {
+class HighlightCommandControllerTest  {
     @Autowired
     private MockMvc mockMvc;
 
@@ -42,7 +42,7 @@ class HighlightControllerTest  {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    private HighlightCommandService highlightCommandService;
+    private HighlightManager manager;
 
 
     @Test
@@ -58,7 +58,7 @@ class HighlightControllerTest  {
         HighlightSelectResponse expectedResponse=mockHighlightSelectResponse(uuids);
         HighlightSelectRequest request=mockHighlightSelectRequest(uuids);
 
-        when(highlightCommandService.selectHighlight(any(HighlightSelectRequest.class),any(Member.class)))
+        when(manager.selectHighlight(any(HighlightSelectRequest.class),any(Member.class)))
                 .thenReturn(expectedResponse);
 
         //when & then
@@ -120,7 +120,7 @@ class HighlightControllerTest  {
                         .build()
         );
 
-        when(highlightCommandService.uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class)))
+        when(manager.uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class)))
                 .thenReturn(expectedResponse);
 
         //when & then
@@ -142,7 +142,7 @@ class HighlightControllerTest  {
                 .andExpect(jsonPath("$.data[1].highlightUrl").value("url"))
                 .andDo(print());
 
-        verify(highlightCommandService).uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class));
+        verify(manager).uploadHighlights(any(UploadHighlight.class),anyList(),any(UUID.class));
     }
     /*
      * Mock HighlightSelectResponse

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryControllerTest.java
@@ -1,20 +1,18 @@
 package com.midas.shootpointer.domain.highlight.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.midas.shootpointer.WithMockCustomMember;
 import com.midas.shootpointer.domain.highlight.business.HighlightManager;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -26,27 +24,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@ExtendWith(MockitoExtension.class)
+@AutoConfigureMockMvc
+@SpringBootTest
+@ActiveProfiles("test")
+@WithMockCustomMember
 class HighlightQueryControllerTest {
+    @Autowired
     private MockMvc mockMvc;
-    private ObjectMapper objectMapper;
 
-    @InjectMocks
-    private HighlightQueryController highlightQueryController;
-
-    @Mock
+    @MockitoBean
     private HighlightManager highlightManager;
-
-    @BeforeEach
-    void setUp(){
-        mockMvc= MockMvcBuilders.standaloneSetup(highlightQueryController)
-                .build();
-        objectMapper=new ObjectMapper();
-    }
 
     @Test
     @DisplayName("특정 유저의 하이라이트 영상 리스트 조회 시 Page<HighlightInfoResponse>를 반환합니다.")
-    @WithMockCustomMember(name = "test",email = "test@naver.com")
     void highlightList() throws Exception {
         // given
         String url = "/api/highlight/list";

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryControllerTest.java
@@ -1,0 +1,91 @@
+package com.midas.shootpointer.domain.highlight.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.midas.shootpointer.WithMockCustomMember;
+import com.midas.shootpointer.domain.highlight.business.HighlightManager;
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class HighlightQueryControllerTest {
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @InjectMocks
+    private HighlightQueryController highlightQueryController;
+
+    @Mock
+    private HighlightManager highlightManager;
+
+    @BeforeEach
+    void setUp(){
+        mockMvc= MockMvcBuilders.standaloneSetup(highlightQueryController)
+                .build();
+        objectMapper=new ObjectMapper();
+    }
+
+    @Test
+    @DisplayName("특정 유저의 하이라이트 영상 리스트 조회 시 Page<HighlightInfoResponse>를 반환합니다.")
+    @WithMockCustomMember(name = "test",email = "test@naver.com")
+    void highlightList() throws Exception {
+        // given
+        String url = "/api/highlight/list";
+
+        UUID highlightId1 = UUID.randomUUID();
+        UUID highlightId2 = UUID.randomUUID();
+        UUID highlightId3 = UUID.randomUUID();
+        UUID highlightId4 = UUID.randomUUID();
+
+        LocalDateTime now = LocalDateTime.now();
+
+        HighlightInfoResponse response1 = HighlightInfoResponse.of(highlightId1, now, 20, 30,"highlight1.mp4.");
+        HighlightInfoResponse response2 = HighlightInfoResponse.of(highlightId2, now.minusDays(1), 10, 40,"highlight2.mp4");
+        HighlightInfoResponse response3 = HighlightInfoResponse.of(highlightId3, now.minusDays(2), 10, 40,"highlight3.mp4");
+        HighlightInfoResponse response4 = HighlightInfoResponse.of(highlightId4, now.minusDays(3), 10, 40,"highlight4.mp4");
+
+        Page<HighlightInfoResponse> expected =
+                new PageImpl<>(List.of(response1, response2,response3,response4));
+
+        when(highlightManager.listByPaging(anyInt(), anyInt(), any(UUID.class)))
+                .thenReturn(expected);
+
+        // when & then
+        mockMvc.perform(get(url)
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content").isArray())
+                .andExpect(jsonPath("$.data.content[0].highlightId").value(highlightId1.toString()))
+                .andExpect(jsonPath("$.data.content[1].highlightId").value(highlightId2.toString()))
+                .andExpect(jsonPath("$.data.content[2].highlightId").value(highlightId3.toString()))
+                .andExpect(jsonPath("$.data.content[3].highlightId").value(highlightId4.toString()))
+                .andExpect(jsonPath("$.data.content.length()").value(4))
+
+                .andExpect(jsonPath("$.data.size").value(4))
+                .andExpect(jsonPath("$.data.totalElements").value(4))
+                .andExpect(jsonPath("$.data.totalPages").value(1))
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImplTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -162,6 +165,21 @@ class HighlightHelperImplTest {
 
         //then
         verify(highlightValidator,times(1)).areValidFiles(list);
+    }
+
+    @Test
+    @DisplayName("highlightUtil.fetchMembersHighlights(memberId,pageable)이 실행되는지 검증합니다.")
+    void fetchMembersHighlights(){
+        //given
+        Page<HighlightEntity> page=Page.empty();
+        UUID memberId=UUID.randomUUID();
+        Pageable pageable= PageRequest.of(0,10);
+
+        //when
+        highlightHelper.fetchMembersHighlights(memberId,pageable);
+
+        //then
+        verify(highlightUtil).fetchMembersHighlights(memberId,pageable);
     }
 
     private MockMultipartFile makeMockFile(String fileName){

--- a/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImplTest.java
@@ -13,6 +13,9 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -102,6 +105,23 @@ class HighlightUtilImplTest {
         assertThatThrownBy(()->highlightUtil.findHighlightByHighlightId(highlightId))
                 .isInstanceOf(CustomException.class)
                 .hasMessage(ErrorCode.NOT_EXIST_HIGHLIGHT.getMessage());
+    }
+
+    @Test
+    @DisplayName("특정 유저의 하이라이트 리스트를 조회할 때 highlightQueryRepository-fetchAllMembersHighlights의 호출을 검증합니다.")
+    void fetchAllMembersHighlights(){
+        //given
+        UUID memberId=UUID.randomUUID();
+        Pageable pageable= PageRequest.of(0,10);
+        Page<HighlightEntity> mockPage=Page.empty();
+
+        when(queryRepository.fetchAllMembersHighlights(any(UUID.class),any(Pageable.class))).thenReturn(mockPage);
+
+        //when
+        highlightUtil.fetchMembersHighlights(memberId,pageable);
+
+        //then
+        verify(queryRepository).fetchAllMembersHighlights(any(UUID.class),any(Pageable.class));
     }
 
     @Test

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
@@ -58,5 +59,35 @@ class HighlightMapperImplTest {
         assertThat(result.getHighlightId()).isEqualTo(entity.getHighlightId());
         assertThat(result.getHighlightIdentifier()).isEqualTo(entity.getHighlightKey());
         assertThat(result.getHighlightUrl()).isEqualTo(entity.getHighlightURL());
+    }
+
+    @Test
+    @DisplayName("HighlightEntity 형태를 HighlightInfoResponse 형태로 매핑합니다.")
+    void infoResponseToEntity(){
+        //given
+        UUID highlightId=UUID.randomUUID();
+        UUID highlightKey=UUID.randomUUID();
+        LocalDateTime now=LocalDateTime.now();
+
+        HighlightEntity entity=HighlightEntity.builder()
+                .highlightURL("url")
+                .highlightKey(highlightKey)
+                .highlightId(highlightId)
+                .isSelected(true)
+                .twoPointCount(20)
+                .threePointCount(30)
+                .build();
+
+        entity.setCreatedAt(now);
+
+        //when
+        HighlightInfoResponse result=mapper.infoResponseToEntity(entity);
+
+        //then
+        assertThat(result.createdDate()).isEqualTo(now);
+        assertThat(result.highlightId()).isEqualTo(highlightId);
+        assertThat(result.totalTwoPoint()).isEqualTo(entity.totalTwoPoint());
+        assertThat(result.totalThreePoint()).isEqualTo(entity.totalThreePoint());
+
     }
 }


### PR DESCRIPTION
## 🍀 이슈 번호

- #179 

---

## ✅ 작업 사항

- #180
- 클라이언트측에서 하이라이트 리스트의 개수를 설정할 수 있도록 `size`값과 `page`값을 입력받아 `paging 방식`으로 구현했습니다.
- 유저의 `하이라이트 영상 집계 동의 = TRUE `조건과 `하이라이트의 선택 유무 = TRUE` 조건을 만족하는 하이라이트 영상만을 조회합니다.
- 위의 조건을 통해 조회된 하이라이트 영상들을 생성 날짜에 맞춰 `최신순`으로 정렬하여 반환합니다. 


---

## ⌨ 기타
