### PR TITLE
🌟 Feature : 마이페이지 정보 조회 및 데이터 추가

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -39,4 +39,23 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
             ORDER BY h.createdAt DESC
         """)
     Page<HighlightEntity> fetchAllMembersHighlights(@Param("memberId")UUID memberId, Pageable pageable);
+    
+    
+    /** ===========================
+     *
+     *  마이페이지 부분
+     *
+     * ============================
+     */
+    // 2점슛 총합
+    @Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
+    Integer sumTwoPointByMemberId(@Param("memberId") UUID memberId);
+    
+    // 3점슛 총합
+    @Query("SELECT COALESCE(SUM(h.threePointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
+    Integer sumThreePointByMemberId(@Param("memberId") UUID memberId);
+    
+    // 하이라이트 개수
+    @Query("SELECT COUNT(h) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
+    Integer countByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 @Repository
@@ -47,15 +46,15 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
      *
      * ============================
      */
-    // 2점슛 총합
-    @Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
-    Integer sumTwoPointByMemberId(@Param("memberId") UUID memberId);
+    // 2점슛 카운트 총합
+    @Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
+    Integer sumTwoPointCountByMemberId(@Param("memberId") UUID memberId);
     
-    // 3점슛 총합
-    @Query("SELECT COALESCE(SUM(h.threePointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
-    Integer sumThreePointByMemberId(@Param("memberId") UUID memberId);
+    // 3점슛 카운트 총합
+    @Query("SELECT COALESCE(SUM(h.threePointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
+    Integer sumThreePointCountByMemberId(@Param("memberId") UUID memberId);
     
     // 하이라이트 개수
-    @Query("SELECT COUNT(h) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
+    @Query("SELECT COUNT(h) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
     Integer countByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
@@ -53,21 +53,15 @@ public class MemberManager {
         Integer backNumber = memberHelper.getBackNumber(memberId);
         
         // 슛 통계 조회
-        Integer totalTwoPoint = memberHelper.getTotalTwoPointCount(memberId);
-        Integer totalThreePoint = memberHelper.getTotalThreePointCount(memberId);
+        Integer totalTwoPointCount = memberHelper.getTotalTwoPointCount(memberId);
+        Integer totalThreePointCount = memberHelper.getTotalThreePointCount(memberId);
         
         // 하이라이트 개수 조회
         Integer highlightCount = memberHelper.getHighlightCount(memberId);
         
-        return MemberResponseDto.builder()
-            .memberId(member.getMemberId())
-            .email(member.getEmail())
-            .username(member.getUsername())
-            .backNumber(backNumber)
-            .totalTwoPoint(totalTwoPoint)
-            .totalThreePoint(totalThreePoint)
-            .highlightCount(highlightCount)
-            .build();
+        return memberMapper.entityToDetailDto(
+            member, backNumber, totalTwoPointCount, totalThreePointCount, highlightCount
+        );
     }
 
     private Member findOrCreateMember(KakaoDTO kakaoDTO) {

--- a/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
@@ -53,8 +53,8 @@ public class MemberManager {
         Integer backNumber = memberHelper.getBackNumber(memberId);
         
         // 슛 통계 조회
-        Integer totalTwoPoint = memberHelper.getTotalTwoPoint(memberId);
-        Integer totalThreePoint = memberHelper.getTotalThreePoint(memberId);
+        Integer totalTwoPoint = memberHelper.getTotalTwoPointCount(memberId);
+        Integer totalThreePoint = memberHelper.getTotalThreePointCount(memberId);
         
         // 하이라이트 개수 조회
         Integer highlightCount = memberHelper.getHighlightCount(memberId);

--- a/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/MemberManager.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.member.business;
 
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
+import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.helper.MemberHelper;
 import com.midas.shootpointer.domain.member.mapper.MemberMapper;
@@ -42,6 +43,31 @@ public class MemberManager {
     public UUID agree(Member member){
         member.agree();
         return member.getMemberId();
+    }
+    
+    public MemberResponseDto getMemberInfo(UUID memberId) {
+        // 회원 정보 조회
+        Member member = memberHelper.findMemberById(memberId);
+        
+        // 등번호 조회
+        Integer backNumber = memberHelper.getBackNumber(memberId);
+        
+        // 슛 통계 조회
+        Integer totalTwoPoint = memberHelper.getTotalTwoPoint(memberId);
+        Integer totalThreePoint = memberHelper.getTotalThreePoint(memberId);
+        
+        // 하이라이트 개수 조회
+        Integer highlightCount = memberHelper.getHighlightCount(memberId);
+        
+        return MemberResponseDto.builder()
+            .memberId(member.getMemberId())
+            .email(member.getEmail())
+            .username(member.getUsername())
+            .backNumber(backNumber)
+            .totalTwoPoint(totalTwoPoint)
+            .totalThreePoint(totalThreePoint)
+            .highlightCount(highlightCount)
+            .build();
     }
 
     private Member findOrCreateMember(KakaoDTO kakaoDTO) {

--- a/src/main/java/com/midas/shootpointer/domain/member/business/query/MemberQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/query/MemberQueryService.java
@@ -1,10 +1,13 @@
 package com.midas.shootpointer.domain.member.business.query;
 
+import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import java.util.Optional;
+import java.util.UUID;
 
 public interface MemberQueryService {
 	
 	Optional<Member> findByEmail(String email);
 	
+	MemberResponseDto getMemberInfo(UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/business/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/business/query/MemberQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package com.midas.shootpointer.domain.member.business.query;
 
+import com.midas.shootpointer.domain.member.business.MemberManager;
+import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.helper.MemberHelper;
 import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberQueryServiceImpl implements MemberQueryService {
 	
 	private final MemberHelper memberHelper;
+	private final MemberManager memberManager;
 	
 	@Override
 	public Optional<Member> findByEmail(String email) {
@@ -23,5 +27,10 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 			return Optional.empty();
 		}
 	}
-
+	
+	@Override
+	public MemberResponseDto getMemberInfo(UUID memberId) {
+		return memberManager.getMemberInfo(memberId);
+	}
+	
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberCommandController.java
@@ -11,6 +11,9 @@ import com.midas.shootpointer.global.annotation.CustomLog;
 import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.CustomUserDetails;
 import com.midas.shootpointer.global.security.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -30,26 +33,59 @@ public class MemberCommandController {
     private final MemberCommandService memberCommandService;
 	private final MemberBackNumberRepository memberBackNumberRepository;
 	private final HighlightQueryRepository highlightQueryRepository;
-    
-    @CustomLog("카카오 소셜 로그인 및 JWT 발급")
+	
+	@CustomLog("카카오 소셜 로그인 및 JWT 발급")
+	@Operation(
+		summary = "카카오 소셜 로그인 및 JWT 발급 API - [담당자 : 박재성]",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 로그인 성공",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = MsgEntity.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "카카오 로그인 실패",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
+		}
+	)
     @GetMapping("/callback")
     public ResponseEntity<MsgEntity> callback(HttpServletRequest request) {
         // 모든 비즈니스 로직은 Service Layer에서 처리
         KakaoDTO kakaoInfo = memberCommandService.processKakaoLogin(request);
         return ResponseEntity.ok().body(new MsgEntity("Success", kakaoInfo));
     }
-    
-    @CustomLog("회원 탈퇴")
-    @DeleteMapping
+	
+	@CustomLog("회원 탈퇴")
+	@Operation(
+		summary = "회원 탈퇴 API - [담당자 : 박재성]",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "회원 탈퇴 실패",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
+		}
+	)
+	@DeleteMapping
     public ResponseEntity<ApiResponse<UUID>> deleteMember(@AuthenticationPrincipal
         CustomUserDetails userDetails) {
         Member member = userDetails.getMember();
         UUID deletedMemberId = memberCommandService.deleteMember(member);
         return ResponseEntity.ok(ApiResponse.ok(deletedMemberId));
     }
-    
-    @CustomLog("회원 정보 조회")
-    @GetMapping("/me")
+	
+	@CustomLog("회원 정보 조회")
+	@Operation(
+		summary = "회원 정보 조회 API - [담당자 : 박재성]",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = MemberResponseDto.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "회원 정보 조회 실패",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
+		}
+	)
+	@GetMapping("/me")
     public MemberResponseDto getCurrentMember() {
         Member currentMember = SecurityUtils.getCurrentMember();
 		UUID memberId = currentMember.getMemberId();

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/command/MemberCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/command/MemberCommandController.java
@@ -1,16 +1,12 @@
-package com.midas.shootpointer.domain.member.controller;
+package com.midas.shootpointer.domain.member.controller.command;
 
-import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.domain.member.business.command.MemberCommandService;
 import com.midas.shootpointer.domain.member.dto.KakaoDTO;
-import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.entity.MsgEntity;
-import com.midas.shootpointer.domain.memberbacknumber.repository.MemberBackNumberRepository;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.CustomUserDetails;
-import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -26,13 +22,11 @@ import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/kakao") // RequestMapping API 엔드포인트 수정할 필요가 있어보임,,, -> 카카오 디벨로퍼스에서도 수정해야함
-@Tag(name = "회원 관리", description = "회원 관리 API")
+@RequestMapping("/kakao")
+@Tag(name = "카카오 로그인 및 탈퇴", description = "카카오 로그인/탈퇴 API")
 public class MemberCommandController {
     
     private final MemberCommandService memberCommandService;
-	private final MemberBackNumberRepository memberBackNumberRepository;
-	private final HighlightQueryRepository highlightQueryRepository;
 	
 	@CustomLog("카카오 소셜 로그인 및 JWT 발급")
 	@Operation(
@@ -53,14 +47,14 @@ public class MemberCommandController {
         return ResponseEntity.ok().body(new MsgEntity("Success", kakaoInfo));
     }
 	
-	@CustomLog("회원 탈퇴")
+	@CustomLog("카카오 회원 탈퇴")
 	@Operation(
-		summary = "회원 탈퇴 API - [담당자 : 박재성]",
+		summary = "카카오 회원 탈퇴 API - [담당자 : 박재성]",
 		responses = {
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "카카오 회원 탈퇴 성공",
 				content = @Content(mediaType = "application/json",
 					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class))),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "회원 탈퇴 실패",
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "카카오 회원 탈퇴 실패",
 				content = @Content(mediaType = "application/json",
 					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
 		}
@@ -72,44 +66,5 @@ public class MemberCommandController {
         UUID deletedMemberId = memberCommandService.deleteMember(member);
         return ResponseEntity.ok(ApiResponse.ok(deletedMemberId));
     }
-	
-	@CustomLog("회원 정보 조회")
-	@Operation(
-		summary = "회원 정보 조회 API - [담당자 : 박재성]",
-		responses = {
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
-				content = @Content(mediaType = "application/json",
-					schema = @Schema(implementation = MemberResponseDto.class))),
-			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "회원 정보 조회 실패",
-				content = @Content(mediaType = "application/json",
-					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
-		}
-	)
-	@GetMapping("/me")
-    public MemberResponseDto getCurrentMember() {
-        Member currentMember = SecurityUtils.getCurrentMember();
-		UUID memberId = currentMember.getMemberId();
-		
-		// 등번호 조회
-		Integer backNumber = memberBackNumberRepository.findByMemberId(memberId)
-			.map(memberBackNumber -> memberBackNumber.getBackNumber().getBackNumber().getNumber())
-			.orElse(0);
-		
-		// 2점, 3점슛 조회
-		Integer totalTwoPoint = highlightQueryRepository.sumTwoPointByMemberId(memberId);
-		Integer totalThreePoint = highlightQueryRepository.sumThreePointByMemberId(memberId);
-		
-		// 하이라이트 개수 조회
-		Integer highlightCount = highlightQueryRepository.countByMemberId(memberId);
-		
-		return MemberResponseDto.builder()
-			.memberId(currentMember.getMemberId())
-			.email(currentMember.getEmail())
-			.username(currentMember.getUsername())
-			.backNumber(backNumber)
-			.totalTwoPoint(totalTwoPoint)
-			.totalThreePoint(totalThreePoint)
-			.highlightCount(highlightCount)
-			.build();
-    }
+
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
@@ -4,12 +4,14 @@ import com.midas.shootpointer.domain.member.business.query.MemberQueryService;
 import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.global.annotation.CustomLog;
+import com.midas.shootpointer.global.dto.ApiResponse;
 import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,8 +37,8 @@ public class MemberQueryController {
 		}
 	)
 	@GetMapping("/me")
-	public MemberResponseDto getCurrentMember() {
+	public ResponseEntity<ApiResponse<MemberResponseDto>> getCurrentMember() {
 		Member currentMember = SecurityUtils.getCurrentMember();
-		return memberQueryService.getMemberInfo(currentMember.getMemberId());
+		return  ResponseEntity.ok(ApiResponse.ok(memberQueryService.getMemberInfo(currentMember.getMemberId())));
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
@@ -1,16 +1,14 @@
 package com.midas.shootpointer.domain.member.controller.query;
 
-import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
+import com.midas.shootpointer.domain.member.business.query.MemberQueryService;
 import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
 import com.midas.shootpointer.domain.member.entity.Member;
-import com.midas.shootpointer.domain.memberbacknumber.repository.MemberBackNumberRepository;
 import com.midas.shootpointer.global.annotation.CustomLog;
 import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,9 +19,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/member")
 @Tag(name = "회원 관리", description = "회원 관리 API")
 public class MemberQueryController {
-	
-	private final MemberBackNumberRepository memberBackNumberRepository;
-	private final HighlightQueryRepository highlightQueryRepository;
+
+	private final MemberQueryService memberQueryService;
 	
 	@CustomLog("회원 정보 조회")
 	@Operation(
@@ -40,28 +37,6 @@ public class MemberQueryController {
 	@GetMapping("/me")
 	public MemberResponseDto getCurrentMember() {
 		Member currentMember = SecurityUtils.getCurrentMember();
-		UUID memberId = currentMember.getMemberId();
-		
-		// 등번호 조회
-		Integer backNumber = memberBackNumberRepository.findByMemberId(memberId)
-			.map(memberBackNumber -> memberBackNumber.getBackNumber().getBackNumber().getNumber())
-			.orElse(0);
-		
-		// 2점, 3점슛 조회
-		Integer totalTwoPoint = highlightQueryRepository.sumTwoPointByMemberId(memberId);
-		Integer totalThreePoint = highlightQueryRepository.sumThreePointByMemberId(memberId);
-		
-		// 하이라이트 개수 조회
-		Integer highlightCount = highlightQueryRepository.countByMemberId(memberId);
-		
-		return MemberResponseDto.builder()
-			.memberId(currentMember.getMemberId())
-			.email(currentMember.getEmail())
-			.username(currentMember.getUsername())
-			.backNumber(backNumber)
-			.totalTwoPoint(totalTwoPoint)
-			.totalThreePoint(totalThreePoint)
-			.highlightCount(highlightCount)
-			.build();
+		return memberQueryService.getMemberInfo(currentMember.getMemberId());
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/query/MemberQueryController.java
@@ -1,0 +1,67 @@
+package com.midas.shootpointer.domain.member.controller.query;
+
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
+import com.midas.shootpointer.domain.member.dto.MemberResponseDto;
+import com.midas.shootpointer.domain.member.entity.Member;
+import com.midas.shootpointer.domain.memberbacknumber.repository.MemberBackNumberRepository;
+import com.midas.shootpointer.global.annotation.CustomLog;
+import com.midas.shootpointer.global.security.SecurityUtils;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+@Tag(name = "회원 관리", description = "회원 관리 API")
+public class MemberQueryController {
+	
+	private final MemberBackNumberRepository memberBackNumberRepository;
+	private final HighlightQueryRepository highlightQueryRepository;
+	
+	@CustomLog("회원 정보 조회")
+	@Operation(
+		summary = "회원 정보 조회 API - [담당자 : 박재성]",
+		responses = {
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 정보 조회 성공",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = MemberResponseDto.class))),
+			@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "4XX", description = "회원 정보 조회 실패",
+				content = @Content(mediaType = "application/json",
+					schema = @Schema(implementation = com.midas.shootpointer.global.dto.ApiResponse.class)))
+		}
+	)
+	@GetMapping("/me")
+	public MemberResponseDto getCurrentMember() {
+		Member currentMember = SecurityUtils.getCurrentMember();
+		UUID memberId = currentMember.getMemberId();
+		
+		// 등번호 조회
+		Integer backNumber = memberBackNumberRepository.findByMemberId(memberId)
+			.map(memberBackNumber -> memberBackNumber.getBackNumber().getBackNumber().getNumber())
+			.orElse(0);
+		
+		// 2점, 3점슛 조회
+		Integer totalTwoPoint = highlightQueryRepository.sumTwoPointByMemberId(memberId);
+		Integer totalThreePoint = highlightQueryRepository.sumThreePointByMemberId(memberId);
+		
+		// 하이라이트 개수 조회
+		Integer highlightCount = highlightQueryRepository.countByMemberId(memberId);
+		
+		return MemberResponseDto.builder()
+			.memberId(currentMember.getMemberId())
+			.email(currentMember.getEmail())
+			.username(currentMember.getUsername())
+			.backNumber(backNumber)
+			.totalTwoPoint(totalTwoPoint)
+			.totalThreePoint(totalThreePoint)
+			.highlightCount(highlightCount)
+			.build();
+	}
+}

--- a/src/main/java/com/midas/shootpointer/domain/member/dto/MemberResponseDto.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/dto/MemberResponseDto.java
@@ -15,5 +15,9 @@ public class MemberResponseDto {
 	private UUID memberId;
 	private String email;
 	private String username;
+	private Integer backNumber;
+	private Integer totalTwoPoint;
+	private Integer totalThreePoint;
+	private Integer highlightCount;
 	
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberHelperImpl.java
@@ -64,4 +64,24 @@ public class MemberHelperImpl implements MemberHelper {
 		return memberUtil.existsByEmail(email);
 	}
 	
+	@Override
+	public Integer getBackNumber(UUID memberId) {
+		return memberUtil.getBackNumber(memberId);
+	}
+	
+	@Override
+	public Integer getTotalTwoPoint(UUID memberId) {
+		return memberUtil.getTotalTwoPoint(memberId);
+	}
+	
+	@Override
+	public Integer getTotalThreePoint(UUID memberId) {
+		return memberUtil.getTotalThreePoint(memberId);
+	}
+	
+	@Override
+	public Integer getHighlightCount(UUID memberId) {
+		return memberUtil.getHighlightCount(memberId);
+	}
+	
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberHelperImpl.java
@@ -70,13 +70,13 @@ public class MemberHelperImpl implements MemberHelper {
 	}
 	
 	@Override
-	public Integer getTotalTwoPoint(UUID memberId) {
-		return memberUtil.getTotalTwoPoint(memberId);
+	public Integer getTotalTwoPointCount(UUID memberId) {
+		return memberUtil.getTotalTwoPointCount(memberId);
 	}
 	
 	@Override
-	public Integer getTotalThreePoint(UUID memberId) {
-		return memberUtil.getTotalThreePoint(memberId);
+	public Integer getTotalThreePointCount(UUID memberId) {
+		return memberUtil.getTotalThreePointCount(memberId);
 	}
 	
 	@Override

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtil.java
@@ -17,9 +17,9 @@ public interface MemberUtil {
 	
 	Integer getBackNumber(UUID memberId);
 	
-	Integer getTotalTwoPoint(UUID memberId);
+	Integer getTotalTwoPointCount(UUID memberId);
 	
-	Integer getTotalThreePoint(UUID memberId);
+	Integer getTotalThreePointCount(UUID memberId);
 	
 	Integer getHighlightCount(UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtil.java
@@ -15,4 +15,11 @@ public interface MemberUtil {
 	
 	boolean existsByEmail(String email);
 	
+	Integer getBackNumber(UUID memberId);
+	
+	Integer getTotalTwoPoint(UUID memberId);
+	
+	Integer getTotalThreePoint(UUID memberId);
+	
+	Integer getHighlightCount(UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtilImpl.java
@@ -55,20 +55,17 @@ public class MemberUtilImpl implements MemberUtil {
 	}
 	
 	@Override
-	public Integer getTotalTwoPoint(UUID memberId) {
-		Integer result = highlightQueryRepository.sumTwoPointByMemberId(memberId);
-		return result != null ? result : 0;
+	public Integer getTotalTwoPointCount(UUID memberId) {
+		return highlightQueryRepository.sumTwoPointCountByMemberId(memberId);
 	}
 	
 	@Override
-	public Integer getTotalThreePoint(UUID memberId) {
-		Integer result = highlightQueryRepository.sumThreePointByMemberId(memberId);
-		return result != null ? result : 0;
+	public Integer getTotalThreePointCount(UUID memberId) {
+		return highlightQueryRepository.sumThreePointCountByMemberId(memberId);
 	}
 	
 	@Override
 	public Integer getHighlightCount(UUID memberId) {
-		Integer result = highlightQueryRepository.countByMemberId(memberId);
-		return result != null ? result : 0;
+		return highlightQueryRepository.countByMemberId(memberId);
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/helper/MemberUtilImpl.java
@@ -1,8 +1,10 @@
 package com.midas.shootpointer.domain.member.helper;
 
+import com.midas.shootpointer.domain.highlight.repository.HighlightQueryRepository;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.member.repository.MemberCommandRepository;
 import com.midas.shootpointer.domain.member.repository.MemberQueryRepository;
+import com.midas.shootpointer.domain.memberbacknumber.repository.MemberBackNumberRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
 import java.util.UUID;
@@ -15,6 +17,8 @@ public class MemberUtilImpl implements MemberUtil {
 	
 	private final MemberQueryRepository memberQueryRepository;
 	private final MemberCommandRepository memberCommandRepository;
+	private final MemberBackNumberRepository memberBackNumberRepository;
+	private final HighlightQueryRepository highlightQueryRepository;
 	
 	@Override
 	public Member findMemberById(UUID memberId) {
@@ -41,5 +45,30 @@ public class MemberUtilImpl implements MemberUtil {
 	@Override
 	public boolean existsByEmail(String email) {
 		return memberQueryRepository.findByEmail(email).isPresent();
+	}
+	
+	@Override
+	public Integer getBackNumber(UUID memberId) {
+		return memberBackNumberRepository.findByMemberId(memberId)
+			.map(memberBackNumber -> memberBackNumber.getBackNumber().getBackNumber().getNumber())
+			.orElse(0);
+	}
+	
+	@Override
+	public Integer getTotalTwoPoint(UUID memberId) {
+		Integer result = highlightQueryRepository.sumTwoPointByMemberId(memberId);
+		return result != null ? result : 0;
+	}
+	
+	@Override
+	public Integer getTotalThreePoint(UUID memberId) {
+		Integer result = highlightQueryRepository.sumThreePointByMemberId(memberId);
+		return result != null ? result : 0;
+	}
+	
+	@Override
+	public Integer getHighlightCount(UUID memberId) {
+		Integer result = highlightQueryRepository.countByMemberId(memberId);
+		return result != null ? result : 0;
 	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/mapper/MemberMapper.java
@@ -9,4 +9,12 @@ public interface MemberMapper {
 	Member dtoToEntity(KakaoDTO kakaoDTO);
 	
 	MemberResponseDto entityToDto(Member member);
+	
+	MemberResponseDto entityToDetailDto(
+		Member member,
+		Integer backNumber,
+		Integer totalTwoPointCount,
+		Integer totalThreePointCount,
+		Integer highlightCount
+	);
 }

--- a/src/main/java/com/midas/shootpointer/domain/member/mapper/MemberMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/mapper/MemberMapperImpl.java
@@ -24,4 +24,23 @@ public class MemberMapperImpl implements MemberMapper {
 			.username(member.getUsername())
 			.build();
 	}
+	
+	@Override
+	public MemberResponseDto entityToDetailDto(
+		Member member,
+		Integer backNumber,
+		Integer totalTwoPointCount,
+		Integer totalThreePointCount,
+		Integer highlightCount
+	) {
+		return MemberResponseDto.builder()
+			.memberId(member.getMemberId())
+			.email(member.getEmail())
+			.username(member.getUsername())
+			.backNumber(backNumber)
+			.totalTwoPoint(totalTwoPointCount)
+			.totalThreePoint(totalThreePointCount)
+			.highlightCount(highlightCount)
+			.build();
+	}
 }

--- a/src/main/java/com/midas/shootpointer/domain/memberbacknumber/repository/MemberBackNumberRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/memberbacknumber/repository/MemberBackNumberRepository.java
@@ -3,7 +3,10 @@ package com.midas.shootpointer.domain.memberbacknumber.repository;
 import com.midas.shootpointer.domain.backnumber.entity.BackNumberEntity;
 import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.domain.memberbacknumber.entity.MemberBackNumberEntity;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +14,7 @@ import java.util.Optional;
 @Repository
 public interface MemberBackNumberRepository extends JpaRepository<MemberBackNumberEntity,Long> {
     Optional<MemberBackNumberEntity> findByBackNumberAndMember( BackNumberEntity backNumber,Member member);
+    
+    @Query("SELECT mbn FROM MemberBackNumberEntity mbn WHERE mbn.member.memberId = :memberId")
+    Optional<MemberBackNumberEntity> findByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/entity/HashTag.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/entity/HashTag.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HashTag {
     TWO_POINT("2점슛"),
-    TREE_POINT("3점슛");
+    THREE_POINT("3점슛");
 
     private final String name;
 }

--- a/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/DummyDataLoader.java
@@ -81,7 +81,7 @@ public class DummyDataLoader implements CommandLineRunner {
             //UTC 기준으로 하여 LocalDateTime를 long 형태로 변환.
             LocalDateTime randomDateTime = LocalDateTime.ofEpochSecond(randomEpoch, 0, ZoneOffset.UTC);
 
-            batchArgs.add(new Object[]{title,content, HashTag.TREE_POINT.name(),highlightId,memberId,likeCnt,randomDateTime,randomDateTime});
+            batchArgs.add(new Object[]{title,content, HashTag.THREE_POINT.name(),highlightId,memberId,likeCnt,randomDateTime,randomDateTime});
 
 
             if (i > 0 && i%batchSize == 0){

--- a/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
@@ -161,7 +161,7 @@ public class SetRealPostDataLoader implements CommandLineRunner {
             //UTC 기준으로 하여 LocalDateTime를 long 형태로 변환.
             LocalDateTime randomDateTime = LocalDateTime.ofEpochSecond(randomEpoch, 0, ZoneOffset.UTC);
 
-            batchArgs.add(new Object[]{postId, title, content, HashTag.TREE_POINT.name(), highlightId, memberId, likeCnt, randomDateTime, randomDateTime});
+            batchArgs.add(new Object[]{postId, title, content, HashTag.THREE_POINT.name(), highlightId, memberId, likeCnt, randomDateTime, randomDateTime});
 
             if (i > 0) {
                 jdbcTemplate.batchUpdate(sql, batchArgs);

--- a/src/test/java/com/midas/shootpointer/domain/like/business/LikeManagerConcurrencyTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/like/business/LikeManagerConcurrencyTest.java
@@ -306,7 +306,7 @@ class LikeManagerConcurrencyTest {
     private PostEntity makeMockPost(Member member) {
         return PostEntity.builder()
                 .member(member)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .content("content")
                 .title("title")
                 .build();

--- a/src/test/java/com/midas/shootpointer/domain/like/business/LikeManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/like/business/LikeManagerTest.java
@@ -126,7 +126,7 @@ class LikeManagerTest  {
 
     private PostEntity makePostEntity(Member member){
         return PostEntity.builder()
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .content("content")
                 .title("title")
                 .member(member)

--- a/src/test/java/com/midas/shootpointer/domain/like/helper/LikeUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/like/helper/LikeUtilImplTest.java
@@ -149,7 +149,7 @@ class LikeUtilImplTest  {
                 .member(member)
                 .title("title")
                 .content("content")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .build();
     }
 

--- a/src/test/java/com/midas/shootpointer/domain/like/repository/LikeQueryRepositoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/like/repository/LikeQueryRepositoryTest.java
@@ -88,7 +88,7 @@ class LikeQueryRepositoryTest {
 
     private PostEntity makeMockPost(Member member){
         return PostEntity.builder()
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .content("content_content")
                 .title("title_title")
                 .member(member)

--- a/src/test/java/com/midas/shootpointer/domain/member/controller/MemberCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/member/controller/MemberCommandControllerTest.java
@@ -112,7 +112,7 @@ class MemberCommandControllerIntegrationTest  {
 		CustomUserDetails userDetails = new CustomUserDetails(member);
 		
 		// when & then
-		mockMvc.perform(get("/kakao/me")
+		mockMvc.perform(get("/member/me")
 				.with(user(userDetails)))
 			.andDo(print())
 			.andExpect(status().isOk())

--- a/src/test/java/com/midas/shootpointer/domain/post/business/PostManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/business/PostManagerTest.java
@@ -245,7 +245,7 @@ class PostManagerTest {
                     .modifiedAt(LocalDateTime.now())
                     .highlightUrl("test")
                     .likeCnt(100L)
-                    .hashTag(HashTag.TREE_POINT.getName())
+                    .hashTag(HashTag.THREE_POINT.getName())
                     .build());
         }
         PostListResponse postListResponse = PostListResponse.of(postId, postResponses);
@@ -622,7 +622,7 @@ class PostManagerTest {
                 .title("title" + str)
                 .content("content" + str)
                 .member(member)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .build();
     }
 
@@ -642,7 +642,7 @@ class PostManagerTest {
                 .member(member)
                 .postId(postId)
                 .highlight(highlight)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .content("content" + str)
                 .title("title" + str)
                 .build();
@@ -751,7 +751,7 @@ class PostManagerTest {
                     .postId(postId)
                     .likeCnt(likeCnt)
                     .memberName("name")
-                    .hashTag(HashTag.TREE_POINT.getName())
+                    .hashTag(HashTag.THREE_POINT.getName())
                     .title(title)
                     .content(content)
                     .highlightUrl("url")

--- a/src/test/java/com/midas/shootpointer/domain/post/business/command/PostCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/business/command/PostCommandServiceImplTest.java
@@ -82,7 +82,7 @@ class PostCommandServiceImplTest {
      * mock PostRequest
      */
     private PostRequest mockPostRequest(){
-        return PostRequest.of(UUID.randomUUID(),"title","content", HashTag.TREE_POINT);
+        return PostRequest.of(UUID.randomUUID(),"title","content", HashTag.THREE_POINT);
     }
     /**
      * mock postEntity
@@ -91,7 +91,7 @@ class PostCommandServiceImplTest {
         return PostEntity.builder()
                 .title("title"+str)
                 .content("content"+str)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .highlight(highlight)
                 .build();
     }

--- a/src/test/java/com/midas/shootpointer/domain/post/controller/PostCommandControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/controller/PostCommandControllerTest.java
@@ -128,7 +128,7 @@ class PostCommandControllerTest  {
      * mock PostRequest
      */
     private PostRequest mockPostRequest() {
-        return PostRequest.of(UUID.randomUUID(), "title", "content", HashTag.TREE_POINT);
+        return PostRequest.of(UUID.randomUUID(), "title", "content", HashTag.THREE_POINT);
     }
 
     /**
@@ -149,7 +149,7 @@ class PostCommandControllerTest  {
         return PostEntity.builder()
                 .title("title")
                 .content("content")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .build();
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/post/dto/response/PostListResponseTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/dto/response/PostListResponseTest.java
@@ -67,7 +67,7 @@ class PostListResponseTest {
                 .memberName("name")
                 .createdAt(LocalDateTime.now())
                 .content("content")
-                .hashTag(HashTag.TREE_POINT.getName())
+                .hashTag(HashTag.THREE_POINT.getName())
                 .title("title")
                 .build();
     }

--- a/src/test/java/com/midas/shootpointer/domain/post/entity/PostEntityTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/entity/PostEntityTest.java
@@ -3,15 +3,12 @@ package com.midas.shootpointer.domain.post.entity;
 import com.midas.shootpointer.domain.backnumber.entity.BackNumber;
 import com.midas.shootpointer.domain.backnumber.entity.BackNumberEntity;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 
 class PostEntityTest {
 
@@ -27,7 +24,7 @@ class PostEntityTest {
         PostEntity original=PostEntity.builder()
                 .content("content1")
                 .title("title1")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .highlight(originalHighlight)
                 .build();
         String changedTitle="title2";
@@ -59,7 +56,7 @@ class PostEntityTest {
 
         PostEntity mockPost=PostEntity.builder()
                 .content(content)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .title(title)
                 .likeCnt(1L)
                 .build();
@@ -84,7 +81,7 @@ class PostEntityTest {
 
         PostEntity mockPost=PostEntity.builder()
                 .content(content)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .title(title)
                 .likeCnt(10L)
                 .build();

--- a/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTest.java
@@ -332,7 +332,7 @@ class PostUtilImplTest {
                 .member(member)
                 .highlight(highlight)
                 .content("content")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .build();
     }
 

--- a/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTestOnlyQuery.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/helper/PostUtilImplTestOnlyQuery.java
@@ -129,7 +129,7 @@ public class PostUtilImplTestOnlyQuery {
                 .member(member)
                 .highlight(highlight)
                 .content("content")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .build();
     }
 

--- a/src/test/java/com/midas/shootpointer/domain/post/mapper/PostElasticSearchMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/mapper/PostElasticSearchMapperImplTest.java
@@ -37,7 +37,7 @@ class PostElasticSearchMapperImplTest {
         PostEntity post = PostEntity.builder()
                 .postId(10L)
                 .content("content")
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .highlight(highlight)
                 .likeCnt(10L)
                 .member(member)

--- a/src/test/java/com/midas/shootpointer/domain/post/mapper/PostMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/mapper/PostMapperImplTest.java
@@ -45,7 +45,7 @@ class PostMapperImplTest  {
         //given
         String content="test_test_test_test_test_test_test_test_test_test_test_test_";
         String title="title";
-        HashTag hashTag=HashTag.TREE_POINT;
+        HashTag hashTag=HashTag.THREE_POINT;
         UUID highlightId=UUID.randomUUID();
         PostRequest request=PostRequest.of(highlightId,title,content,hashTag);
         Member mock=makeMockMember();
@@ -79,7 +79,7 @@ class PostMapperImplTest  {
                 .title(title)
                 .content(content)
                 .highlight(highlight)
-                .hashTag(HashTag.TREE_POINT)
+                .hashTag(HashTag.THREE_POINT)
                 .member(mock)
                 .build();
 

--- a/src/test/java/com/midas/shootpointer/domain/post/repository/PostCustomElasticSearchRepositoryImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/repository/PostCustomElasticSearchRepositoryImplTest.java
@@ -670,9 +670,9 @@ class PostCustomElasticSearchRepositoryImplTest {
                 String title="엘라스틱 테스트 테스트";
 
                 elasticSearchRepository.saveAll(List.of(
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,1L,title),
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,2L,title),
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,3L,title),
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,1L,title),
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,2L,title),
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,3L,title),
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,4L,title),
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,5L,title)
                 ));
@@ -833,7 +833,7 @@ class PostCustomElasticSearchRepositoryImplTest {
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,1L,title),
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,2L,title),
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,3L,title),
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,4L,title)
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,4L,title)
                 ));
 
                 //when
@@ -936,8 +936,8 @@ class PostCustomElasticSearchRepositoryImplTest {
                 String keyword3="2점슛";
 
                 elasticSearchRepository.saveAll(List.of(
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,1L,title),
-                        makePostDocumentWithHashTag(now,now,HashTag.TREE_POINT,likeCnt,2L,title),
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,1L,title),
+                        makePostDocumentWithHashTag(now,now,HashTag.THREE_POINT,likeCnt,2L,title),
 
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,3L,title),
                         makePostDocumentWithHashTag(now,now,HashTag.TWO_POINT,likeCnt,4L,title),
@@ -1013,7 +1013,7 @@ class PostCustomElasticSearchRepositoryImplTest {
                 .createdAt(time)
                 .likeCnt(likeCnt)
                 .memberName("test")
-                .hashTag(HashTag.TREE_POINT.getName())
+                .hashTag(HashTag.THREE_POINT.getName())
                 .highlightUrl("url")
                 .build();
     }

--- a/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
@@ -109,7 +109,7 @@ class PostQueryRepositoryTest {
                             .highlight(highlight)
                             .content("내용1 + 내용 2 + 내용 "+i)
                             .title("제목 1 + 제목2 + 제목 "+i)
-                            .hashTag(HashTag.TREE_POINT)
+                            .hashTag(HashTag.THREE_POINT)
                             .likeCnt(10L)
                             .build()
             );
@@ -156,7 +156,7 @@ class PostQueryRepositoryTest {
                             .highlight(highlight)
                             .content("내용1 + 내용 2 + 내용 "+i)
                             .title("제목 1 + 제목2 + 제목 "+i)
-                            .hashTag(HashTag.TREE_POINT)
+                            .hashTag(HashTag.THREE_POINT)
                             .likeCnt(10L)
                             .build()
             );


### PR DESCRIPTION
## 🍀 이슈 번호
<!-- 이슈 번호를 작성해주세요 ex) #11 -->
- #198 

---

## ✅ 작업 사항

### 정보 요구사항
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/daed438e-f25f-4ce9-a73d-12b21d26b15a" />

## 1️⃣
기존 `MemberResponseDto`에는 memberId, email, username 필드만 존재했습니다. 해당 Dto는 임시로 회원 정보를 불러오기 위한 작업으로, **기존 요구사항에 부합하는 회원 정보를 조회하기 위해** 기존 필드에 등번호(BackNumber), 2점슛 총합(totalTwoPoint), 3점슛(totalThreePoint), 하이라이트 개수(highlightCount)를 추가하였습니다.

### MemberResponseDto
```java
@Getter
@Builder
@NoArgsConstructor
@AllArgsConstructor
public class MemberResponseDto {
	
	private UUID memberId;
	private String email;
	private String username;
	private Integer backNumber;
	private Integer totalTwoPoint;
	private Integer totalThreePoint;
	private Integer highlightCount;
	
}
```

## 2️⃣
2점슛과 3점슛 총합을 계산하는 Query를 작성할 때, null값 계산을 방지하기 위해 **COALESCE**를 사용해 null을 SUM할 때 0으로 계산하여 합산하도록 구현하였습니다.

```java
@Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
```


추가적으로 프로젝트의 마감까지 촉박한 시간으로 인한 테스트 코드 커버리지는 @tkv00 님과의 합의 하에 **PostMan**으로 대체하기로 하였습니다. 

---

## ⌨ 기타

### 사소한 수정 사항

➡️ MemberCommandController에 있던 회원 정보 조회를 CQRS 패턴에 부합하게 적용하기 위해 MemberQueryController로 이동

➡️ HashTag에 있던 3점슛 Enum 타입 오타 수정