### PR TITLE
🌟 Feature : 자신이 좋아요 누른 게시물 조회 기능

### DIFF
--- a/src/main/java/com/midas/shootpointer/domain/member/controller/MemberQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/member/controller/MemberQueryController.java
@@ -1,0 +1,13 @@
+package com.midas.shootpointer.domain.member.controller;
+
+import com.midas.shootpointer.domain.like.business.LikeManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member")
+public class MemberQueryController {
+    private final LikeManager likeManager;
+}

--- a/src/main/java/com/midas/shootpointer/domain/post/business/PostManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/PostManager.java
@@ -252,6 +252,15 @@ public class PostManager {
         return PostListResponse.of(lastPostId, postResponses);
     }
 
+    @Transactional(readOnly = true)
+    public PostListResponse getMyLikedPosts(UUID memId,Long lastPostId,int size){
+        //1. 유저가 좋아요 누른 게시물 조회
+        List<PostEntity> postEntities=postHelper.getMyLikedPost(memId,lastPostId,size);
+
+        //2. entity -> dto 변환
+        return postMapper.entityToDto(postEntities);
+    }
+
     /**
      * List<PostSearchHit> -> PostListResponse 변환 inner class
      */

--- a/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryService.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryService.java
@@ -20,4 +20,6 @@ public interface PostQueryService {
     List<SearchAutoCompleteResponse> suggest(String keyword);
     
     PostListResponse getMyPosts(UUID memberId);
+
+    PostListResponse myLikedPost(UUID memberId,Long lastPostId,int size);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImpl.java
@@ -5,12 +5,12 @@ import com.midas.shootpointer.domain.post.dto.response.PostListResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -45,5 +45,10 @@ public class PostQueryServiceImpl implements PostQueryService{
     @Override
     public PostListResponse getMyPosts(UUID memberId) {
         return postManager.getMyPosts(memberId);
+    }
+
+    @Override
+    public PostListResponse myLikedPost(UUID memberId, Long lastPostId, int size) {
+        return postManager.getMyLikedPosts(memberId,lastPostId,size);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/controller/PostQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/controller/PostQueryController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 
 @RestController
@@ -183,4 +184,14 @@ public class PostQueryController {
         Member member = SecurityUtils.getCurrentMember();
         return ResponseEntity.ok(ApiResponse.ok(postQueryService.getMyPosts(member.getMemberId())));
     }
+
+    @GetMapping("/my/like")
+    public ResponseEntity<ApiResponse<PostListResponse>> myLikedPost(
+            @RequestParam(required = false,defaultValue = "922337203685477580") Long lastPostId,
+            @RequestParam(required = false,defaultValue = "10")int size
+    ){
+        UUID memberId =SecurityUtils.getCurrentMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(postQueryService.myLikedPost(memberId,lastPostId,size)));
+    }
+
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostHelperImpl.java
@@ -94,4 +94,9 @@ public class PostHelperImpl implements PostHelper{
         return postUtil.findPostsByPostIds(postIds);
     }
 
+    @Override
+    public List<PostEntity> getMyLikedPost(UUID memberId, Long lastPostId, int size) {
+        return postUtil.getMyLikedPost(memberId,lastPostId,size);
+    }
+
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtil.java
@@ -18,4 +18,5 @@ public interface PostUtil {
     List<PostEntity> getPostEntitiesByPostTitleOrPostContent(String search,Long postId,int size);
     List<Long> findPostIdsByMemberId(UUID memberId);
     List<PostEntity> findPostsByPostIds(List<Long> postIds);
+    List<PostEntity> getMyLikedPost(UUID memberId,Long lastPostId,int size);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/helper/simple/PostUtilImpl.java
@@ -7,13 +7,12 @@ import com.midas.shootpointer.domain.post.repository.PostCommandRepository;
 import com.midas.shootpointer.domain.post.repository.PostQueryRepository;
 import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.exception.CustomException;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -94,5 +93,10 @@ public class PostUtilImpl implements PostUtil{
     @Override
     public List<PostEntity> findPostsByPostIds(List<Long> postIds) {
         return postQueryRepository.findPostsByPostIds(postIds);
+    }
+
+    @Override
+    public List<PostEntity> getMyLikedPost(UUID memberId, Long lastPostId, int size) {
+        return postQueryRepository.findMyLikedPost(memberId,size,lastPostId);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
@@ -89,7 +89,7 @@ public interface PostQueryRepository extends JpaRepository<PostEntity,Long>{
                 p.post_id < :lastPostId
             AND
                 l.member_id = :memberId
-            ORDER BY p.post_id DESC
+            ORDER BY l.created_at DESC
             LIMIT :size
             """,nativeQuery = true)
     List<PostEntity> findMyLikedPost(@Param("memberId") UUID memberId, @Param("size") int size, @Param("lastPostId")Long lastPostId);

--- a/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
@@ -2,7 +2,6 @@ package com.midas.shootpointer.domain.post.repository;
 
 import com.midas.shootpointer.domain.post.entity.PostEntity;
 import jakarta.persistence.LockModeType;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
@@ -11,6 +10,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 @Repository
 public interface PostQueryRepository extends JpaRepository<PostEntity,Long>{
     Optional<PostEntity> findByPostId(Long postId);
@@ -80,4 +80,18 @@ public interface PostQueryRepository extends JpaRepository<PostEntity,Long>{
         "WHERE p.postId IN :postIds " +
         "ORDER BY p.postId DESC")
     List<PostEntity> findPostsByPostIds(@Param(value = "postIds") List<Long> postIds);
+
+    @Query(value = """
+            SELECT * FROM post as p
+            INNER JOIN
+                member as m ON p.member_id = m.member_id
+            INNER JOIN
+                like_table as l ON l.member_id = m.member_id
+            WHERE
+                p.member_id = :memberId
+                AND p.post_id < :lastPostId
+            ORDER BY p.post_id DESC
+            LIMIT :size
+            """,nativeQuery = true)
+    List<PostEntity> findMyLikedPost(@Param("memberId") UUID memberId, @Param("size") int size, @Param("lastPostId")Long lastPostId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/repository/PostQueryRepository.java
@@ -82,14 +82,13 @@ public interface PostQueryRepository extends JpaRepository<PostEntity,Long>{
     List<PostEntity> findPostsByPostIds(@Param(value = "postIds") List<Long> postIds);
 
     @Query(value = """
-            SELECT * FROM post as p
+            SELECT p.* FROM post as p
             INNER JOIN
-                member as m ON p.member_id = m.member_id
-            INNER JOIN
-                like_table as l ON l.member_id = m.member_id
+                like_table as l ON l.post_id = p.post_id
             WHERE
-                p.member_id = :memberId
-                AND p.post_id < :lastPostId
+                p.post_id < :lastPostId
+            AND
+                l.member_id = :memberId
             ORDER BY p.post_id DESC
             LIMIT :size
             """,nativeQuery = true)

--- a/src/test/java/com/midas/shootpointer/domain/post/business/PostManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/business/PostManagerTest.java
@@ -562,7 +562,82 @@ class PostManagerTest {
         verify(postHelper, never()).findPostsByPostIds(any());
         verify(postMapper, never()).entityToDto(any(PostEntity.class));
     }
-    
+
+    @Test
+    @DisplayName("유저가 좋아요를 누른 게시물 목록을 정상적으로 반환합니다.")
+    void getMyLikedPosts_SUCCESS() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Long lastPostId = Long.MAX_VALUE;
+        int size = 10;
+
+        PostEntity post1 = PostEntity.builder()
+                .content("content1")
+                .hashTag(HashTag.TREE_POINT)
+                .likeCnt(12L)
+                .title("title1")
+                .build();
+
+        PostEntity post2 = PostEntity.builder()
+                .content("content2")
+                .hashTag(HashTag.TREE_POINT)
+                .likeCnt(20L)
+                .title("title2")
+                .build();
+
+        List<PostEntity> postEntities = List.of(post1, post2);
+
+        PostResponse dto1 = PostResponse.builder()
+                .content("title1")
+                .content("content1")
+                .likeCnt(12L)
+                .build();
+        PostResponse dto2 =PostResponse.builder()
+                .content("title2")
+                .content("content2")
+                .likeCnt(20L)
+                .build();
+        List<PostResponse> postResponses = List.of(dto1, dto2);
+
+        PostListResponse expectedResponse = PostListResponse.of(2L, postResponses);
+
+        when(postHelper.getMyLikedPost(memberId, lastPostId, size)).thenReturn(postEntities);
+        when(postMapper.entityToDto(postEntities)).thenReturn(expectedResponse);
+
+        // when
+        PostListResponse actualResponse = postManager.getMyLikedPosts(memberId, lastPostId, size);
+
+        // then
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+        verify(postHelper, times(1)).getMyLikedPost(memberId, lastPostId, size);
+        verify(postMapper, times(1)).entityToDto(postEntities);
+    }
+
+    @Test
+    @DisplayName("좋아요 누른 게시물이 없는 경우 빈 리스트를 반환합니다.")
+    void getMyLikedPosts_EmptyList() {
+        // given
+        UUID memberId = UUID.randomUUID();
+        Long lastPostId = Long.MAX_VALUE;
+        int size = 10;
+
+        List<PostEntity> emptyList = List.of();
+        PostListResponse emptyResponse = PostListResponse.of(null, List.of());
+
+        when(postHelper.getMyLikedPost(memberId, lastPostId, size)).thenReturn(emptyList);
+        when(postMapper.entityToDto(emptyList)).thenReturn(emptyResponse);
+
+        // when
+        PostListResponse actualResponse = postManager.getMyLikedPosts(memberId, lastPostId, size);
+
+        // then
+        assertThat(actualResponse.getPostList()).isEmpty();
+        verify(postHelper, times(1)).getMyLikedPost(memberId, lastPostId, size);
+        verify(postMapper, times(1)).entityToDto(emptyList);
+
+    }
+
+
     // PostResponse 생성 헬퍼 메서드 추가
     private PostResponse makePostResponse(
         LocalDateTime time,

--- a/src/test/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/business/query/PostQueryServiceImplTest.java
@@ -6,7 +6,6 @@ import com.midas.shootpointer.domain.post.dto.response.PostResponse;
 import com.midas.shootpointer.domain.post.dto.response.PostSort;
 import com.midas.shootpointer.domain.post.dto.response.SearchAutoCompleteResponse;
 import com.midas.shootpointer.domain.post.entity.HashTag;
-import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Mockito.*;
 
@@ -122,6 +122,22 @@ class PostQueryServiceImplTest {
         
         //then
         verify(postManager, times(1)).getMyPosts(memberId);
+    }
+
+    @Test
+    @DisplayName("내가 좋아요한 게시물 조회시 postManager - getMyPosts(memberId)의 호출을 확인합니다.")
+    void myLikedPost(){
+        //given
+        UUID memberId = UUID.randomUUID();
+        Long lastPostId=Long.MAX_VALUE;
+        int size=10;
+
+        //when
+        when(postManager.getMyLikedPosts(memberId,lastPostId,size)).thenReturn(postListResponse);
+        postQueryService.myLikedPost(memberId,lastPostId,size);
+
+        //then
+        verify(postManager, times(1)).getMyLikedPosts(memberId,lastPostId,size);
     }
     
     private PostResponse makePostResponse(LocalDateTime time,Long postId){

--- a/src/test/java/com/midas/shootpointer/domain/post/helper/PostHelperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/helper/PostHelperImplTest.java
@@ -6,7 +6,6 @@ import com.midas.shootpointer.domain.post.entity.PostEntity;
 import com.midas.shootpointer.domain.post.helper.simple.PostHelperImpl;
 import com.midas.shootpointer.domain.post.helper.simple.PostUtil;
 import com.midas.shootpointer.domain.post.helper.simple.PostValidation;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class PostHelperImplTest {
@@ -251,5 +250,22 @@ class PostHelperImplTest {
         //then
         assertThat(result).hasSize(3);
         verify(postUtil, times(1)).findPostsByPostIds(postIds);
+    }
+
+    @Test
+    @DisplayName("memberId를 이용해 유저 자신이 좋아요를 누른 게시물을 생성일자 순으로 조회합니다. - postUtil.getMyLikedPost(memberId,lastPostId,size)")
+    void getMyLikedPost(){
+        //given
+        UUID memberId=UUID.randomUUID();
+        Long lastPostId=Long.MAX_VALUE;
+        List<PostEntity> expectedPosts=List.of(postEntity,postEntity);
+        when(postUtil.getMyLikedPost(memberId,lastPostId,10)).thenReturn(expectedPosts);
+
+        //when
+        List<PostEntity> result=postHelper.getMyLikedPost(memberId,lastPostId,10);
+
+        //then
+        assertThat(result).hasSize(2);
+        verify(postUtil,times(1)).getMyLikedPost(memberId,lastPostId,10);
     }
 }

--- a/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/post/repository/PostQueryRepositoryTest.java
@@ -253,7 +253,23 @@ class PostQueryRepositoryTest {
                 .containsExactlyElementsOf(expectedSorted);
     }
 
+    @DisplayName("member가 좋아요 누른 게시물이 존재하지 않으면 빈 리스트를 반환합니다.")
+    @Test
+    void myLikedPost_EMPTY(){
+        //given
+        memberA = memberRepository.save(Member.builder()
+                .email("test1@naver.com")
+                .username("test1")
+                .isAggregationAgreed(true)
+                .build()
+        );
 
+        //when
+        List<PostEntity> results=postQueryRepository.findMyLikedPost(memberA.getMemberId(),10,Long.MAX_VALUE);
+
+        //then
+        assertThat(results).isEqualTo(Collections.EMPTY_LIST);
+    }
     /*
     ======================================대용량 데이터 사용 쿼리 테스트======================================
      */


### PR DESCRIPTION
## 🍀 이슈 번호

- #192 

- 기존 `게시물 검색 조회`와 같은 방식으로 구현했습니다.

```sql
SELECT p.* FROM post as p
            INNER JOIN
                like_table as l ON l.post_id = p.post_id
            WHERE
                p.post_id < :lastPostId
            AND
                l.member_id = :memberId
            ORDER BY l.created_at DESC
            LIMIT :size
```

   -  **lastPostId**와 **size**를 파라미터 값으로 받아 **NoOffset + Slice** 형식으로 구현.
   - **like** 엔티티의 **created_at**가 최신순으로 정렬되어 반환될 수 있도록 구현.
   - 쿼리 조회 시 조회된 값이 없으면, 빈 리스트를 반환합니다. 

---

## ✅ 작업 사항

- #193 


- #194 



close #193 
close #194 

---

## ⌨ 기타
