### PR TITLE
🌟 Feature : 월 별 생성된 하이라이트 조회 - 캘린더형

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,6 +98,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+	implementation 'com.github.p493cc:logback-color:1.0.3'
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
 
 	//redisson
 	implementation 'org.redisson:redisson-spring-boot-starter:3.18.0'

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
-	implementation 'com.github.p493cc:logback-color:1.0.3'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 
 

--- a/src/main/java/com/midas/shootpointer/batch/reader/ranking/RankingReader.java
+++ b/src/main/java/com/midas/shootpointer/batch/reader/ranking/RankingReader.java
@@ -80,7 +80,6 @@ public class RankingReader{
 
         /**
          *  1. 시간 조건
-         *     + is_selected = true
          *     + is_aggregation_agreed = true
          */
         queryProvider.setSelectClause("""
@@ -103,7 +102,6 @@ public class RankingReader{
         queryProvider.setWhereClause("""
                 WHERE
                   m.is_aggregation_agreed = true
-                  AND h.is_selected = true
                   AND h.created_at BETWEEN :begin AND :end
                 """);
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -91,7 +91,7 @@ public class HighlightManager {
         /*
         *   2. 하이라이트 엔티티 생성
          */
-        List<HighlightEntity> entities=factory.createHighlightEntities(request.getHighlightUrls(),request.getHighlightIdentifier(),member,backNumber);
+        List<HighlightEntity> entities=factory.createHighlightEntities(request.getHighlightUrls(),request.getHighlightIdentifier(),member,backNumber,request.getCreatedAt());
 
         /*
             3. DB 저장

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -118,4 +118,8 @@ public class HighlightManager {
         PeriodType convertedType=PeriodType.valueOf(period);
         return highlightHelper.fetchAllMembersHighlights(convertedType);
     }
+
+    public HighlightCalendarResponse fetchCalendar(int year, int month) {
+
+    }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -18,7 +18,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.UUID;
 
 @Component
@@ -119,7 +121,27 @@ public class HighlightManager {
         return highlightHelper.fetchAllMembersHighlights(convertedType);
     }
 
-    public HighlightCalendarResponse fetchCalendar(int year, int month) {
+    public HighlightCalendarResponse fetchCalendar(int year, int month,UUID memberId) {
+        /**
+         * 1. year,month 입력 값 검증
+         */
+        highlightHelper.isValidDateRange(year,month);
 
+        /**
+         * 2.년 월 기간 내 생성된 하이라이트 영상 조회 - flat data 조회
+         */
+        List<HighlightInfoResponse> flatHighlightList=highlightHelper.fetchFlatHighlightList(year,month,memberId);
+
+        /**
+         * 3. flat data 그룹핑한 데이터 조회
+         */
+        TreeMap<LocalDate,List<HighlightInfoResponse>> groupingHighlights=highlightHelper.groupingHighlights(flatHighlightList);
+
+        /**
+         * 4.date와 매핑된 데이터 반환
+         */
+        List<HighlightCalendarDaysResponse> daysResponses=mapper.groupingHighlightToDaysResponse(groupingHighlights);
+
+        return new HighlightCalendarResponse(year,month,daysResponses);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/HighlightManager.java
@@ -36,36 +36,6 @@ public class HighlightManager {
     /*==========================
     *
     *HighlightManager
-    * 여러개의 하이라이트 영상 중 유저가 선택하는 메서드
-    * @parm request : 요청 dto memberId : 멤버 Id
-    * @return 선택된 하이라이트 영상 Id 리스트
-    * @author kimdoyeon
-    * @version 1.0.0
-    * @date 25. 10. 7.
-    *
-    ==========================**/
-    @Transactional
-    @CustomLog
-    public HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member){
-        List<UUID> selectedIds=request.getSelectedHighlightIds();
-        /**
-         * 1. 유저가 선택 요청한 하이라이트 Id 리스트 -> 엔티티로 가져오기
-         */
-        List<HighlightEntity> highlights = selectedIds.stream()
-                .map(highlightHelper::findHighlightByHighlightId)
-                .toList();
-
-        /*
-         * 2. 선택 수행
-         */
-        highlights.forEach(entity -> entity.select(member));
-
-        return mapper.entityToResponse(selectedIds);
-    }
-
-    /*==========================
-    *
-    *HighlightManager
     * 1. openCv 에서 생성한 하이라이트 영상 주소 -> DB에 하이라이트 URL 저장
     * @parm
     * @return

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandService.java
@@ -1,15 +1,9 @@
 package com.midas.shootpointer.domain.highlight.business.command;
 
 import com.midas.shootpointer.domain.highlight.dto.HighlightRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.member.entity.Member;
 
 import java.util.UUID;
 
 public interface HighlightCommandService {
-    HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member);
-
     void uploadHighlights(HighlightRequest highlights, UUID memberId);
 }
-////

--- a/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImpl.java
@@ -16,21 +16,6 @@ import java.util.UUID;
 @Slf4j
 public class HighlightCommandServiceImpl implements HighlightCommandService {
     private final HighlightManager manager;
-    /*==========================
-    *
-    *HighlightCommandServiceImpl
-    *
-    * @parm HighlightSelectRequest : 하이라이트 선택 요청 Dto , token : JWT
-    * @return 하이라이트 선택 성공 시 선택한 하이라이트 id 반환 dto
-    * @author kimdoyeon
-    * @version 1.0.0
-    * @date 6/23/25
-    *
-    ==========================**/
-    @Override
-    public HighlightSelectResponse selectHighlight(HighlightSelectRequest request, Member member) {
-        return manager.selectHighlight(request,member);
-    }
 
     /*==========================
     *

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightCommandController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightCommandController.java
@@ -2,11 +2,7 @@ package com.midas.shootpointer.domain.highlight.controller;
 
 import com.midas.shootpointer.domain.highlight.business.command.HighlightCommandService;
 import com.midas.shootpointer.domain.highlight.dto.HighlightRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.member.entity.Member;
 import com.midas.shootpointer.global.dto.ApiResponse;
-import com.midas.shootpointer.global.security.SecurityUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,15 +19,6 @@ import java.util.UUID;
 @Tag(name = "하이라이트 URL 전송 / 하이라이트 선택")
 public class HighlightCommandController {
     private final HighlightCommandService highlightCommandService;
-
-    @PostMapping("/select")
-    public ResponseEntity<ApiResponse<HighlightSelectResponse>> selectHighlight(
-            @RequestBody HighlightSelectRequest request
-    ) {
-        Member member = SecurityUtils.getCurrentMember();
-
-        return ResponseEntity.ok(ApiResponse.ok(highlightCommandService.selectHighlight(request, member)));
-    }
 
     @Operation(
             summary = "하이라이트 URL 전송 API (OpenCV 에서 사용) - [담당자 : 김도연]",

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -1,6 +1,7 @@
 package com.midas.shootpointer.domain.highlight.controller;
 
 import com.midas.shootpointer.domain.highlight.business.HighlightManager;
+import com.midas.shootpointer.domain.highlight.dto.HighlightCalendarResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.global.dto.ApiResponse;
@@ -34,5 +35,10 @@ public class HighlightQueryController {
     @GetMapping
     public ResponseEntity<ApiResponse<List<PeriodHighlightResponse>>> periodHighlight(@RequestParam(value = "period")String period){
         return ResponseEntity.ok(ApiResponse.ok(manager.fetchAllMembersHighlights(period)));
+    }
+
+    @GetMapping("/calendar")
+    public ResponseEntity<ApiResponse<HighlightCalendarResponse>> fetchCalendar(@RequestParam(value = "year") int year,@RequestParam(value = "month")int month){
+        return ResponseEntity.ok(ApiResponse.ok(manager.fetchCalendar(year,month)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -32,11 +32,20 @@ public class HighlightQueryController {
         return ResponseEntity.ok(ApiResponse.ok( manager.listByPaging(page,size,memberId)));
     }
 
+    /**
+     * @param period WEEKLY : 이번 주 / MONTHLY : 이번 달
+     * @return 이번 주 / 이번 달 인기 하이라이트 조회
+     */
     @GetMapping
     public ResponseEntity<ApiResponse<List<PeriodHighlightResponse>>> periodHighlight(@RequestParam(value = "period")String period){
         return ResponseEntity.ok(ApiResponse.ok(manager.fetchAllMembersHighlights(period)));
     }
 
+    /**
+     * @param year 조회 연도
+     * @param month 조회 달
+     * @return 캘린더형 유저의 날짜별 하이라이트 영상 리스트 조회
+     */
     @GetMapping("/calendar")
     public ResponseEntity<ApiResponse<HighlightCalendarResponse>> fetchCalendar(
             @RequestParam(value = "year") int year,

--- a/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/controller/HighlightQueryController.java
@@ -38,7 +38,11 @@ public class HighlightQueryController {
     }
 
     @GetMapping("/calendar")
-    public ResponseEntity<ApiResponse<HighlightCalendarResponse>> fetchCalendar(@RequestParam(value = "year") int year,@RequestParam(value = "month")int month){
-        return ResponseEntity.ok(ApiResponse.ok(manager.fetchCalendar(year,month)));
+    public ResponseEntity<ApiResponse<HighlightCalendarResponse>> fetchCalendar(
+            @RequestParam(value = "year") int year,
+            @RequestParam(value = "month")int month
+    ){
+        UUID memberId=SecurityUtils.getCurrentMemberId();
+        return ResponseEntity.ok(ApiResponse.ok(manager.fetchCalendar(year,month,memberId)));
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/DateTimeRange.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/DateTimeRange.java
@@ -1,0 +1,6 @@
+package com.midas.shootpointer.domain.highlight.dto;
+
+import java.time.LocalDateTime;
+
+public record DateTimeRange(LocalDateTime start,LocalDateTime end) {
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarDaysResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarDaysResponse.java
@@ -1,0 +1,13 @@
+package com.midas.shootpointer.domain.highlight.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record HighlightCalendarDaysResponse(
+        @NotNull LocalDate date,
+        @NotNull Integer count,
+        @NotNull List<HighlightInfoResponse> highlights
+) {
+}

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarResponse.java
@@ -1,0 +1,19 @@
+package com.midas.shootpointer.domain.highlight.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record HighlightCalendarResponse(
+        @NotNull Integer year,
+        @NotNull Integer month,
+        @NotNull List<CalendarDaysResponse> days
+) {
+    public record CalendarDaysResponse(
+            @NotNull LocalDate date,
+            @NotNull List<HighlightInfoResponse> highlights
+            ){
+    }
+}
+

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarResponse.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightCalendarResponse.java
@@ -2,18 +2,12 @@ package com.midas.shootpointer.domain.highlight.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public record HighlightCalendarResponse(
         @NotNull Integer year,
         @NotNull Integer month,
-        @NotNull List<CalendarDaysResponse> days
+        @NotNull List<HighlightCalendarDaysResponse> days
 ) {
-    public record CalendarDaysResponse(
-            @NotNull LocalDate date,
-            @NotNull List<HighlightInfoResponse> highlights
-            ){
-    }
 }
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightSelectRequest.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/dto/HighlightSelectRequest.java
@@ -1,14 +1,12 @@
 package com.midas.shootpointer.domain.highlight.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
 import java.util.UUID;
 
 @AllArgsConstructor
@@ -18,9 +16,8 @@ import java.util.UUID;
 @Schema(description = "하이라이트 선택 요청 DTO 입니다.")
 public class HighlightSelectRequest {
     /**
-     * 3가지 중 2개 선택
+     * 게시물 - 3가지 중 1개 선택
      */
-    @NotEmpty
-    @Size(min = 2,max = 2,message = "하이라이트를 정확히 2개를 선택해주세요.")
-    private List<UUID> selectedHighlightIds;
+    @NotNull
+    private UUID selectedHighlightIds;
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.UuidGenerator;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -54,6 +55,9 @@ public class HighlightEntity extends BaseEntity {
     @Column(name = "three_point_count",nullable = true)
     @Builder.Default
     private Integer threePointCount=0;
+
+    @Column(name = "video_created_at")
+    private LocalDateTime videoCreatedAt;
 
     /*
     =========== [ 도메인-행위 ] ==============

--- a/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntity.java
@@ -2,9 +2,7 @@ package com.midas.shootpointer.domain.highlight.entity;
 
 import com.midas.shootpointer.domain.backnumber.entity.BackNumberEntity;
 import com.midas.shootpointer.domain.member.entity.Member;
-import com.midas.shootpointer.global.common.ErrorCode;
 import com.midas.shootpointer.global.entity.BaseEntity;
-import com.midas.shootpointer.global.exception.CustomException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,10 +33,6 @@ public class HighlightEntity extends BaseEntity {
     @Column(name = "highlight_key",nullable = false,columnDefinition = "uuid")
     private UUID highlightKey;
 
-    @Column(name = "is_selected")
-    @Builder.Default
-    private Boolean isSelected=false;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id",nullable = false, columnDefinition = "uuid")
     private Member member;
@@ -62,17 +56,6 @@ public class HighlightEntity extends BaseEntity {
     /*
     =========== [ 도메인-행위 ] ==============
      */
-    public void select(Member actor){
-        //유저의 하이라이트 영상이 아닌경우
-        if (!actor.getMemberId().equals(member.getMemberId())){
-            throw new CustomException(ErrorCode.IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID);
-        }
-        //이미 선택된 하이라이트 영상인 경우
-        if (Boolean.TRUE.equals(this.isSelected)){
-            throw new CustomException(ErrorCode.EXISTED_SELECTED);
-        }
-        this.isSelected=true;
-    }
 
     //2점 슛 계산
     public int totalTwoPoint(){

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -14,7 +14,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
 
 @Component
@@ -49,22 +49,22 @@ public class HighlightHelperImpl implements HighlightHelper{
 
     @Override
     public DateTimeRange calculateDateTimeRange(PeriodType type, LocalDateTime now) {
-        return null;
+        return highlightUtil.calculateDateTimeRange(type,now);
     }
 
     @Override
-    public Map<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
-        return Map.of();
+    public TreeMap<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
+        return highlightUtil.groupingHighlights(flatHighlightList);
     }
 
     @Override
     public List<HighlightInfoResponse> fetchFlatHighlightList(int year, int month, UUID memberId) {
-        return List.of();
+        return highlightUtil.fetchFlatHighlightList(year,month,memberId);
     }
 
     @Override
     public DateTimeRange getMonthDateTimeRange(int year, int month) {
-        return null;
+        return highlightUtil.getMonthDateTimeRange(year,month);
     }
 
     @Override
@@ -100,5 +100,10 @@ public class HighlightHelperImpl implements HighlightHelper{
     @Override
     public void areValidFiles(List<MultipartFile> files) {
         highlightValidator.areValidFiles(files);
+    }
+
+    @Override
+    public void isValidDateRange(int year, int month) {
+        highlightValidator.isValidDateRange(year,month);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -1,5 +1,7 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.dto.DateTimeRange;
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodType;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
@@ -9,8 +11,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Component
@@ -51,6 +55,21 @@ public class HighlightHelperImpl implements HighlightHelper{
     @Override
     public LocalDateTime calculateEndDate(PeriodType type, LocalDateTime now) {
         return highlightUtil.calculateEndDate(type,now);
+    }
+
+    @Override
+    public Map<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
+        return Map.of();
+    }
+
+    @Override
+    public List<HighlightInfoResponse> fetchFlatHighlightList(int year, int month, UUID memberId) {
+        return List.of();
+    }
+
+    @Override
+    public DateTimeRange getMonthDateTimeRange(int year, int month) {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightHelperImpl.java
@@ -48,13 +48,8 @@ public class HighlightHelperImpl implements HighlightHelper{
     }
 
     @Override
-    public LocalDateTime calculateStartDate(PeriodType type, LocalDateTime now) {
-        return highlightUtil.calculateStartDate(type,now);
-    }
-
-    @Override
-    public LocalDateTime calculateEndDate(PeriodType type, LocalDateTime now) {
-        return highlightUtil.calculateEndDate(type,now);
+    public DateTimeRange calculateDateTimeRange(PeriodType type, LocalDateTime now) {
+        return null;
     }
 
     @Override

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -20,8 +20,7 @@ public interface HighlightUtil {
     List<HighlightEntity> savedAll(List<HighlightEntity> entities);
     Page<HighlightEntity> fetchMembersHighlights(UUID memberId, Pageable pageable);
     List<PeriodHighlightResponse> fetchAllMembersHighlights(PeriodType period);
-    LocalDateTime calculateStartDate(PeriodType type,LocalDateTime now);
-    LocalDateTime calculateEndDate(PeriodType type,LocalDateTime now);
+    DateTimeRange calculateDateTimeRange(PeriodType type,LocalDateTime now);
     Map<LocalDate,List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList);
     List<HighlightInfoResponse> fetchFlatHighlightList(int year,int month,UUID memberId);
     DateTimeRange getMonthDateTimeRange(int year, int month);

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.dto.DateTimeRange;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodType;
@@ -23,4 +24,5 @@ public interface HighlightUtil {
     LocalDateTime calculateEndDate(PeriodType type,LocalDateTime now);
     Map<LocalDate,List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList);
     List<HighlightInfoResponse> fetchFlatHighlightList(int year,int month,UUID memberId);
+    DateTimeRange getMonthDateTimeRange(int year, int month);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -1,13 +1,16 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodType;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface HighlightUtil {
@@ -18,4 +21,6 @@ public interface HighlightUtil {
     List<PeriodHighlightResponse> fetchAllMembersHighlights(PeriodType period);
     LocalDateTime calculateStartDate(PeriodType type,LocalDateTime now);
     LocalDateTime calculateEndDate(PeriodType type,LocalDateTime now);
+    Map<LocalDate,List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList);
+    List<HighlightInfoResponse> fetchFlatHighlightList(int year,int month,UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtil.java
@@ -11,7 +11,7 @@ import org.springframework.data.domain.Pageable;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Map;
+import java.util.TreeMap;
 import java.util.UUID;
 
 public interface HighlightUtil {
@@ -21,7 +21,7 @@ public interface HighlightUtil {
     Page<HighlightEntity> fetchMembersHighlights(UUID memberId, Pageable pageable);
     List<PeriodHighlightResponse> fetchAllMembersHighlights(PeriodType period);
     DateTimeRange calculateDateTimeRange(PeriodType type,LocalDateTime now);
-    Map<LocalDate,List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList);
+    TreeMap<LocalDate,List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList);
     List<HighlightInfoResponse> fetchFlatHighlightList(int year,int month,UUID memberId);
     DateTimeRange getMonthDateTimeRange(int year, int month);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -91,8 +91,8 @@ public class HighlightUtilImpl implements HighlightUtil{
      * @return LocalDate(ex. 2022-10-22T) 형태로 그룹핑
      */
     @Override
-    public Map<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
-        Map<LocalDate,List<HighlightInfoResponse>> results=new HashMap<>();
+    public TreeMap<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
+        TreeMap<LocalDate,List<HighlightInfoResponse>> results=new TreeMap<>();
 
         for (HighlightInfoResponse response:flatHighlightList){
             //LocalDateTime -> LocalDate

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -79,52 +79,11 @@ public class HighlightUtilImpl implements HighlightUtil{
     @Override
     public List<PeriodHighlightResponse> fetchAllMembersHighlights(PeriodType period) {
         LocalDateTime now=LocalDateTime.now();
-        LocalDateTime startDate=calculateStartDate(period,now);
-        LocalDateTime endDate=calculateEndDate(period,now);
+        LocalDateTime startDate=calculateDateTimeRange(period,now).start();
+        LocalDateTime endDate=calculateDateTimeRange(period,now).end();
         Pageable page= PageRequest.of(0,HIGHLIGHT_SIZE);
 
         return highlightQueryRepository.fetchPeriodHighlight(startDate,endDate,FETCH_SIZE,page);
-    }
-
-    @Override
-    public LocalDateTime calculateStartDate(PeriodType type,LocalDateTime now) {
-        switch (type){
-            case MONTHLY -> {
-                return now.withDayOfMonth(1).toLocalDate().atStartOfDay();
-            }
-            case WEEKLY -> {
-                return now
-                        .with(DayOfWeek.MONDAY)
-                        .toLocalDate()
-                        .atStartOfDay();
-            }
-            case DAILY -> {
-                return now.toLocalDate()
-                        .atStartOfDay();
-            }
-            default -> throw new IllegalArgumentException("LocalDateTime 지원하지 않는 타입");
-        }
-    }
-
-    @Override
-    public LocalDateTime calculateEndDate(PeriodType type,LocalDateTime now) {
-        switch (type){
-            case MONTHLY -> {
-                return now.withDayOfMonth(now.toLocalDate().lengthOfMonth())
-                        .toLocalDate()
-                        .atTime(23,59,59);
-            }
-            case WEEKLY -> {
-                return now.with(DayOfWeek.SUNDAY)
-                        .toLocalDate()
-                        .atTime(23,59,59);
-            }
-            case DAILY -> {
-                return now.toLocalDate()
-                        .atTime(23,59,59);
-            }
-            default -> throw new IllegalArgumentException("LocalDateTime 지원하지 않는 타입");
-        }
     }
 
     /**
@@ -160,6 +119,38 @@ public class HighlightUtilImpl implements HighlightUtil{
     public List<HighlightInfoResponse> fetchFlatHighlightList(int year, int month,UUID memberId) {
         DateTimeRange range=getMonthDateTimeRange(year,month);
         return highlightQueryRepository.fetchFlatHighlights(range.start(),range.end(),memberId);
+    }
+
+    @Override
+    public DateTimeRange calculateDateTimeRange(PeriodType type, LocalDateTime now) {
+        LocalDateTime start;
+        LocalDateTime end;
+
+        switch (type){
+            case MONTHLY -> {
+                start= now.withDayOfMonth(1).toLocalDate().atStartOfDay();
+                end=now.withDayOfMonth(now.toLocalDate().lengthOfMonth())
+                        .toLocalDate()
+                        .atTime(23,59,59);
+            }
+            case WEEKLY -> {
+                start=now
+                        .with(DayOfWeek.MONDAY)
+                        .toLocalDate()
+                        .atStartOfDay();
+                end=now.with(DayOfWeek.SUNDAY)
+                        .toLocalDate()
+                        .atTime(23,59,59);
+            }
+            case DAILY -> {
+                start= now.toLocalDate()
+                        .atStartOfDay();
+                end= now.toLocalDate()
+                        .atTime(23,59,59);
+            }
+            default -> throw new IllegalArgumentException("LocalDateTime 지원하지 않는 타입");
+        }
+        return new DateTimeRange(start,end);
     }
 
     @Override

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.dto.DateTimeRange;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodType;
@@ -157,13 +158,18 @@ public class HighlightUtilImpl implements HighlightUtil{
      */
     @Override
     public List<HighlightInfoResponse> fetchFlatHighlightList(int year, int month,UUID memberId) {
+        DateTimeRange range=getMonthDateTimeRange(year,month);
+        return highlightQueryRepository.fetchFlatHighlights(range.start(),range.end(),memberId);
+    }
+
+    @Override
+    public DateTimeRange getMonthDateTimeRange(int year, int month) {
         LocalDate startDate = LocalDate.of(year, month, 1);
         LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
 
         LocalDateTime start = startDate.atStartOfDay();
         LocalDateTime end = endDate.atTime(23, 59, 59);
-
-        return highlightQueryRepository.fetchFlatHighlights(start,end,memberId);
+        return new DateTimeRange(start,end);
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightUtilImpl.java
@@ -1,5 +1,6 @@
 package com.midas.shootpointer.domain.highlight.helper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodType;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
@@ -19,9 +20,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Component
 @Slf4j
@@ -123,6 +124,46 @@ public class HighlightUtilImpl implements HighlightUtil{
             }
             default -> throw new IllegalArgumentException("LocalDateTime 지원하지 않는 타입");
         }
+    }
+
+    /**
+     * @param flatHighlightList 년 월 기간 내 생성된 하이라이트 영상 목록
+     * @return LocalDate(ex. 2022-10-22T) 형태로 그룹핑
+     */
+    @Override
+    public Map<LocalDate, List<HighlightInfoResponse>> groupingHighlights(List<HighlightInfoResponse> flatHighlightList) {
+        Map<LocalDate,List<HighlightInfoResponse>> results=new HashMap<>();
+
+        for (HighlightInfoResponse response:flatHighlightList){
+            //LocalDateTime -> LocalDate
+            LocalDate date=response.createdDate().toLocalDate();
+
+            //key 매핑
+            results.putIfAbsent(date,new ArrayList<>());
+
+            //value 삽입
+            results.get(date).add(response);
+        }
+
+        //flatHighlightList는 오름차순으로 정렬되어 반환되므로 따로 정렬할 필요 없음.
+        return results;
+    }
+
+    /**
+     * @param year 연도
+     * @param month 달
+     * @param memberId 멤버 ID
+     * @return 유저의 입력된 년 월 기간 내 생성된 하이라이트 영상 조회
+     */
+    @Override
+    public List<HighlightInfoResponse> fetchFlatHighlightList(int year, int month,UUID memberId) {
+        LocalDate startDate = LocalDate.of(year, month, 1);
+        LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());
+
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDate.atTime(23, 59, 59);
+
+        return highlightQueryRepository.fetchFlatHighlights(start,end,memberId);
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidator.java
@@ -13,4 +13,5 @@ public interface HighlightValidator {
     void isValidFileSize(MultipartFile file);
     boolean isExistDirectory(String directory);
     void areValidFiles(List<MultipartFile> files);
+    void isValidDateRange(int year,int month);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/helper/HighlightValidatorImpl.java
@@ -27,6 +27,11 @@ public class HighlightValidatorImpl implements HighlightValidator{
     private static final long MAX_FILE_SIZE = 500L * 1024L * 1024L;
     private final HighlightQueryRepository highlightQueryRepository;
 
+    private static final int MAX_YEAR=2100;
+    private static final int MIN_YEAR=2000;
+
+    private static final int JANUARY=1;
+    private static final int DECEMBER=12;
     @Override
     public boolean filesExist(String directory) {
         Path directoryPath= Paths.get(directory);
@@ -86,5 +91,11 @@ public class HighlightValidatorImpl implements HighlightValidator{
             isValidFileSize(file);
             isValidMp4File(file);
         });
+    }
+
+    @Override
+    public void isValidDateRange(int year, int month) {
+        if(year>MAX_YEAR || year<MIN_YEAR) throw new CustomException(ErrorCode.INVALID_YEAR);
+        if (month<JANUARY || month>DECEMBER) throw new CustomException(ErrorCode.INVALID_MONTH);
     }
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactory.java
@@ -7,6 +7,7 @@ import com.midas.shootpointer.domain.member.entity.Member;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,7 +20,8 @@ public class HighlightFactory {
     public List<HighlightEntity> createHighlightEntities(List<HighlightInfo> highlightInfos,
                                                          UUID key,
                                                          Member member,
-                                                         BackNumberEntity backNumber
+                                                         BackNumberEntity backNumber,
+                                                         LocalDateTime createAt
     ){
         return highlightInfos.stream()
                 .map(info -> HighlightEntity.builder()
@@ -29,6 +31,7 @@ public class HighlightFactory {
                         .twoPointCount(info.twoPointCount())
                         .threePointCount(info.threePointCount())
                         .backNumber(backNumber)
+                        .videoCreatedAt(createAt)
                         .build())
                 .toList();
     }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
@@ -1,13 +1,16 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightCalendarDaysResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
 public interface HighlightMapper {
     HighlightSelectResponse entityToResponse(List<UUID> selectedHighlights);
     HighlightInfoResponse infoResponseToEntity(HighlightEntity entity);
+    HighlightCalendarDaysResponse flatResponseToDaysResponse(List<HighlightInfoResponse> flatHighlightsResponse, LocalDate date);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapper.java
@@ -7,10 +7,11 @@ import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.UUID;
 
 public interface HighlightMapper {
     HighlightSelectResponse entityToResponse(List<UUID> selectedHighlights);
     HighlightInfoResponse infoResponseToEntity(HighlightEntity entity);
-    HighlightCalendarDaysResponse flatResponseToDaysResponse(List<HighlightInfoResponse> flatHighlightsResponse, LocalDate date);
+    List<HighlightCalendarDaysResponse> groupingHighlightToDaysResponse(TreeMap<LocalDate,List<HighlightInfoResponse>> groupingHighlights);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -7,7 +7,9 @@ import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeMap;
 import java.util.UUID;
 
 @Component
@@ -26,8 +28,15 @@ public class HighlightMapperImpl implements HighlightMapper{
     }
 
     @Override
-    public HighlightCalendarDaysResponse flatResponseToDaysResponse(List<HighlightInfoResponse> flatHighlightsResponse, LocalDate date) {
-        return new HighlightCalendarDaysResponse(date,flatHighlightsResponse.size(),flatHighlightsResponse);
+    public List<HighlightCalendarDaysResponse> groupingHighlightToDaysResponse(TreeMap<LocalDate, List<HighlightInfoResponse>> groupingHighlights) {
+        List<HighlightCalendarDaysResponse> calendarDaysResponses=new ArrayList<>();
+
+        for (LocalDate date:groupingHighlights.keySet()){
+            List<HighlightInfoResponse> daysResponse=groupingHighlights.get(date);
+
+            calendarDaysResponses.add(new HighlightCalendarDaysResponse(date,daysResponse.size(),daysResponse));
+        }
+        return calendarDaysResponses;
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImpl.java
@@ -1,10 +1,12 @@
 package com.midas.shootpointer.domain.highlight.mapper;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightCalendarDaysResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,6 +23,11 @@ public class HighlightMapperImpl implements HighlightMapper{
     @Override
     public HighlightInfoResponse infoResponseToEntity(HighlightEntity entity) {
         return HighlightInfoResponse.of(entity.getHighlightId(),entity.getCreatedAt(),entity.totalTwoPoint(),entity.totalThreePoint(),entity.getHighlightURL());
+    }
+
+    @Override
+    public HighlightCalendarDaysResponse flatResponseToDaysResponse(List<HighlightInfoResponse> flatHighlightsResponse, LocalDate date) {
+        return new HighlightCalendarDaysResponse(date,flatHighlightsResponse.size(),flatHighlightsResponse);
     }
 
 

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -93,7 +93,7 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
         AND
         h.createdAt BETWEEN :startDate AND :endDate
     ORDER BY
-        h.createdAt ASC
+        h.videoCreatedAt ASC
     """ )
     List<HighlightInfoResponse> fetchFlatHighlights(LocalDateTime startDate,LocalDateTime endDate,UUID memberId);
     /**

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -1,5 +1,7 @@
 package com.midas.shootpointer.domain.highlight.repository;
 
+import com.midas.shootpointer.domain.highlight.dto.HighlightCalendarDaysResponse;
+import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
 import com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import org.springframework.data.domain.Page;
@@ -43,6 +45,9 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
             """)
     Page<HighlightEntity> fetchAllMembersHighlights(@Param("memberId") UUID memberId, Pageable pageable);
 
+    /**
+     * 기간 내에 눌린 좋아요 개수 기준으로 내림차순으로 인기 하이라이트 조회.
+     */
     @Query(value =
             """
                     SELECT DISTINCT new com.midas.shootpointer.domain.highlight.dto.PeriodHighlightResponse
@@ -69,6 +74,28 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
     )
     List<PeriodHighlightResponse> fetchPeriodHighlight(LocalDateTime startDate, LocalDateTime endDate, int limit,Pageable page);
 
+    /**
+     * 캘린더형 유저의 하이라이트 영상 목록 조회
+     */
+    @Query(value = """
+    SELECT
+        new com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse(
+            h.highlightId,
+            h.createdAt,
+            (SUM (h.twoPointCount) * 2),
+            (SUM (h.threePointCount) * 3),
+            h.highlightURL
+        )
+    FROM
+        HighlightEntity AS h
+    WHERE
+        h.member.memberId = :memberId
+        AND
+        h.createdAt BETWEEN :startDate AND :endDate
+    ORDER BY
+        h.createdAt DESC
+    """ )
+    List<HighlightInfoResponse> fetchFlatHighlights(LocalDateTime startDate,LocalDateTime endDate,UUID memberId);
     /**
      * ===========================
      * <p>

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -82,8 +82,8 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
         new com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse(
             h.highlightId,
             h.createdAt,
-            (SUM (h.twoPointCount) * 2),
-            (SUM (h.threePointCount) * 3),
+            h.twoPointCount * 2  ,
+            h.threePointCount * 3 ,
             h.highlightURL
         )
     FROM

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -67,6 +67,13 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
                     
                     WHERE
                             l.createdAt BETWEEN :startDate AND :endDate
+                    GROUP BY
+                            h.highlightURL,
+                            h.highlightId,
+                            p.postId,
+                            m.username,
+                            p.likeCnt,
+                            p.title
                     ORDER BY
                              COUNT(l) DESC
                     """

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -39,7 +39,6 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
                 INNER JOIN
                 Member as m ON h.member.memberId = m.memberId
                 WHERE m.isAggregationAgreed = true
-                  AND h.isSelected = true
                   AND m.memberId =:memberId
                 ORDER BY h.createdAt DESC
             """)
@@ -104,14 +103,14 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
      * ============================
      */
     // 2점슛 카운트 총합
-    @Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
+    @Query("SELECT COALESCE(SUM(h.twoPointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
     Integer sumTwoPointCountByMemberId(@Param("memberId") UUID memberId);
 
     // 3점슛 카운트 총합
-    @Query("SELECT COALESCE(SUM(h.threePointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
+    @Query("SELECT COALESCE(SUM(h.threePointCount), 0) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
     Integer sumThreePointCountByMemberId(@Param("memberId") UUID memberId);
 
     // 하이라이트 개수
-    @Query("SELECT COUNT(h) FROM HighlightEntity h WHERE h.member.memberId = :memberId AND h.isSelected = true")
+    @Query("SELECT COUNT(h) FROM HighlightEntity h WHERE h.member.memberId = :memberId")
     Integer countByMemberId(@Param("memberId") UUID memberId);
 }

--- a/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
+++ b/src/main/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepository.java
@@ -93,7 +93,7 @@ public interface HighlightQueryRepository extends JpaRepository<HighlightEntity,
         AND
         h.createdAt BETWEEN :startDate AND :endDate
     ORDER BY
-        h.createdAt DESC
+        h.createdAt ASC
     """ )
     List<HighlightInfoResponse> fetchFlatHighlights(LocalDateTime startDate,LocalDateTime endDate,UUID memberId);
     /**

--- a/src/main/java/com/midas/shootpointer/domain/post/entity/HashTag.java
+++ b/src/main/java/com/midas/shootpointer/domain/post/entity/HashTag.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum HashTag {
     TWO_POINT("2점슛"),
-    THREE_POINT("3점슛");
+    THREE_POINT("3점슛"),
+    BLOCKING("블락");
 
     private final String name;
 }

--- a/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
+++ b/src/main/java/com/midas/shootpointer/global/common/ErrorCode.java
@@ -51,6 +51,8 @@ public enum ErrorCode {
     FILE_SIZE_EXCEEDED(20204,HttpStatus.BAD_REQUEST,"파일의 크기가 초과했습니다.(제한 : 200MB)"),
     FILE_UPLOAD_FAILED(20205,HttpStatus.BAD_REQUEST,"파일 업로드에 실패했습니다."),
     IMAGE_CONVERT_FAILED(20206,HttpStatus.INTERNAL_SERVER_ERROR,"이미지 파일을 변환하던 중 오류가 발생했습니다."),
+    INVALID_YEAR(20207,HttpStatus.BAD_REQUEST,"유효한 연도를 입력해주세요.(2000년 ~ 2100년)"),
+    INVALID_MONTH(20208,HttpStatus.BAD_REQUEST,"유효한 달을 입력해주세요.(1월 ~ 12월)"),
 
     //300(member - entity) part
     IS_AGGREGATION_TRUE(30001,HttpStatus.BAD_REQUEST,"이미 하이라이트 영상 정보 수집에 동의했습니다."),

--- a/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
@@ -159,7 +159,6 @@ public class SetRealPostDataLoader implements CommandLineRunner {
                             .highlightURL("test")
                             .highlightKey(UUID.randomUUID())
                             .highlightURL(videoUrl)
-                            .isSelected(true)
                             .backNumber(backNumber)
                             .threePointCount(random.nextInt(1, 100))
                             .twoPointCount(random.nextInt(1, 100))

--- a/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
@@ -135,6 +135,21 @@ public class SetRealPostDataLoader implements CommandLineRunner {
         for (int i = 0; i < SIZE; i++) {
             Member member = memberList.get(random.nextInt(memberList.size()));
             BackNumberEntity backNumber = memberBackNumberMap.get(member);
+            LocalDateTime randomDateTime;
+
+            if (i < 20) {
+                //이번주 데이터 (7일 이내)
+                randomDateTime = LocalDateTime.now().minusDays(new Random().nextInt(7));
+            } else if (i < 40) {
+                //이번달 데이터 (30일 이내)
+                randomDateTime = LocalDateTime.now().minusDays(new Random().nextInt(30));
+            } else {
+                // 기존 3년 랜덤 데이터
+                long start = threeYearsAgo.toEpochSecond(ZoneOffset.UTC);
+                long end = now.toEpochSecond(ZoneOffset.UTC);
+                long randomEpoch = start + (long) (random.nextDouble() * (end - start));
+                randomDateTime = LocalDateTime.ofEpochSecond(randomEpoch, 0, ZoneOffset.UTC);
+            }
             /*
               Highlight 생성
              */
@@ -149,6 +164,7 @@ public class SetRealPostDataLoader implements CommandLineRunner {
                             .threePointCount(random.nextInt(1, 100))
                             .twoPointCount(random.nextInt(1, 100))
                             .member(member)
+                            .videoCreatedAt(randomDateTime)
                             .build()
             );
 
@@ -165,21 +181,7 @@ public class SetRealPostDataLoader implements CommandLineRunner {
             Long likeCnt = postData.getLikeCnt();
             //게시물 id
             Long postId = postData.getPostId();
-            LocalDateTime randomDateTime;
 
-            if (i < 20) {
-                //이번주 데이터 (7일 이내)
-                randomDateTime = LocalDateTime.now().minusDays(new Random().nextInt(7));
-            } else if (i < 40) {
-                //이번달 데이터 (30일 이내)
-                randomDateTime = LocalDateTime.now().minusDays(new Random().nextInt(30));
-            } else {
-                // 기존 3년 랜덤 데이터
-                long start = threeYearsAgo.toEpochSecond(ZoneOffset.UTC);
-                long end = now.toEpochSecond(ZoneOffset.UTC);
-                long randomEpoch = start + (long) (random.nextDouble() * (end - start));
-                randomDateTime = LocalDateTime.ofEpochSecond(randomEpoch, 0, ZoneOffset.UTC);
-            }
 
             //UTC 기준으로 하여 LocalDateTime를 long 형태로 변환.
             jdbcTemplate.update(sql,

--- a/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
+++ b/src/main/java/com/midas/shootpointer/test/SetRealPostDataLoader.java
@@ -12,10 +12,7 @@ import com.midas.shootpointer.domain.member.repository.MemberCommandRepository;
 import com.midas.shootpointer.domain.memberbacknumber.entity.MemberBackNumberEntity;
 import com.midas.shootpointer.domain.memberbacknumber.repository.MemberBackNumberRepository;
 import com.midas.shootpointer.domain.post.entity.HashTag;
-import com.midas.shootpointer.domain.post.entity.PostDocument;
 import com.midas.shootpointer.domain.post.entity.PostEntity;
-import com.midas.shootpointer.domain.post.mapper.PostElasticSearchMapper;
-import com.midas.shootpointer.domain.post.repository.PostElasticSearchRepository;
 import com.midas.shootpointer.domain.post.repository.PostQueryRepository;
 import com.midas.shootpointer.test.BasketballPostDataGenerator.PostData;
 import lombok.RequiredArgsConstructor;
@@ -49,8 +46,8 @@ public class SetRealPostDataLoader implements CommandLineRunner {
     private final MemberCommandRepository memberRepository;
     private final HighlightCommandRepository highlightCommandRepository;
     private final PostQueryRepository postQueryRepository;
-    private final PostElasticSearchMapper mapper;
-    private final PostElasticSearchRepository postElasticSearchRepository;
+    //private final PostElasticSearchMapper mapper;
+    //private final PostElasticSearchRepository postElasticSearchRepository;
     private final BackNumberRepository backNumberRepository;
     private final MemberBackNumberRepository memberBackNumberRepository;
     private final LikeCommandRepository likeCommandRepository;
@@ -223,12 +220,12 @@ public class SetRealPostDataLoader implements CommandLineRunner {
         List<PostEntity> repositoryAll = postQueryRepository.findAllWithMemberAndHighlight();
 
         // PostEntity → PostDocument 변환
-        List<PostDocument> docs = repositoryAll.stream()
+        /*List<PostDocument> docs = repositoryAll.stream()
                 .map(mapper::entityToDoc)
                 .toList();
 
         postElasticSearchRepository.saveAll(docs);
-        System.out.println("ES - 삽입 완료");
+        System.out.println("ES - 삽입 완료");*/
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -195,12 +195,16 @@ sse:
   clean-up-interval: 60000
 
 #logging
+p6spy:
+  config:
+    logMessageFormat: com.p6spy.engine.spy.appender.CustomLineFormat
+    customLogMessageFormat: |
+      %(currentTime) | took %(executionTime)ms | category=%(category)
+      %(sqlPretty)
+      -------------------------------------------------------------
 
 decorator:
   datasource:
     p6spy:
       enable-logging: true
-
-p6spy:
-  formatting:
-    stdout: true
+      log-format: multiline

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,9 @@ jwt:
   refresh_expiration_time: 259200000
 
 spring:
+  output:
+    ansi:
+      enabled: always
   jackson:
     serialization:
       write-dates-as-timestamps: false
@@ -134,7 +137,9 @@ management:
   endpoint:
     health:
       show-details: always
-
+  health:
+    elasticsearch:
+      enabled: false
 #Kakao
 kakao:
   auth:
@@ -188,3 +193,14 @@ sse:
   event-name: progress
   cache-max-size: 360
   clean-up-interval: 60000
+
+#logging
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
+
+p6spy:
+  formatting:
+    stdout: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -193,18 +193,3 @@ sse:
   event-name: progress
   cache-max-size: 360
   clean-up-interval: 60000
-
-#logging
-p6spy:
-  config:
-    logMessageFormat: com.p6spy.engine.spy.appender.CustomLineFormat
-    customLogMessageFormat: |
-      %(currentTime) | took %(executionTime)ms | category=%(category)
-      %(sqlPretty)
-      -------------------------------------------------------------
-
-decorator:
-  datasource:
-    p6spy:
-      enable-logging: true
-      log-format: multiline

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <property name="CONSOLE_LOG_PATTERN"
+              value="%yellow(%date{yyyy-MM-dd HH:mm:ss.SSS}) %highlight(%-5level) [%cyan(%thread)] %green(%logger{36}) - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/main/resources/query/ranking.sql
+++ b/src/main/resources/query/ranking.sql
@@ -13,7 +13,6 @@ WITH filtered AS (
         member AS m ON h.member_id = m.member_id
     WHERE
         m.is_aggregation_agreed = TRUE
-      AND h.is_selected = TRUE
       AND h.created_at >= ?
       AND h.created_at <  ?
 )

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
@@ -1,8 +1,6 @@
 package com.midas.shootpointer.domain.highlight.business;
 
 import com.midas.shootpointer.domain.highlight.dto.HighlightInfoResponse;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
 import com.midas.shootpointer.domain.highlight.entity.HighlightEntity;
 import com.midas.shootpointer.domain.highlight.repository.HighlightCommandRepository;
 import com.midas.shootpointer.domain.member.entity.Member;
@@ -20,7 +18,6 @@ import org.springframework.test.context.DynamicPropertySource;
 
 import java.nio.file.Path;
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,41 +52,6 @@ class HighlightManagerTest  {
     void cleanUp(){
         repository.deleteAll();
     }
-
-    @Test
-    @DisplayName("하이라이트 영상 객체를 호출하고 가져온 하이라이트 영상의 is_selected를 true 상태로 변환합니다.")
-    void selectHighlight(){
-        //given
-        //하이라이트 영상 URL 저장
-        UUID highlightKey=UUID.randomUUID();
-        Member member=memberCommandRepository.save(makeMember());
-        List<HighlightEntity> highlightEntities=List.of(
-                makeHighlightEntity("url",highlightKey,member),
-                makeHighlightEntity("url",highlightKey,member),
-                makeHighlightEntity("url",highlightKey,member)
-        );
-        highlightEntities=repository.saveAll(highlightEntities);
-        List<UUID> selectedIds=highlightEntities.stream()
-                .map(HighlightEntity::getHighlightId)
-                .toList();
-
-        HighlightSelectRequest request=HighlightSelectRequest.builder()
-                .selectedHighlightIds(selectedIds)
-                .build();
-
-
-        //when
-        HighlightSelectResponse response=highlightManager.selectHighlight(request,member);
-
-        //then
-        assertThat(response).isNotNull();
-        assertThat(response.getSelectedHighlightIds()).hasSize(3);
-        assertThat(response.getSelectedHighlightIds().get(0)).isEqualTo(selectedIds.get(0));
-        assertThat(response.getSelectedHighlightIds().get(1)).isEqualTo(selectedIds.get(1));
-        assertThat(response.getSelectedHighlightIds().get(2)).isEqualTo(selectedIds.get(2));
-
-    }
-
 
     @Test
     @DisplayName("실제 하이라이트 영상을 저장하고 엔티티를 DB에 저장한 후 DTO로 변환합니다.")

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/HighlightManagerTest.java
@@ -75,7 +75,6 @@ class HighlightManagerTest  {
             HighlightEntity entity=HighlightEntity.builder()
                     .highlightKey(UUID.randomUUID())
                     .highlightURL("https://cdn.example.com/video" + i + ".mp4")
-                    .isSelected(true)
                     .member(member)
                     .build();
             entity.setCreatedAt(LocalDateTime.now().minusDays(i));

--- a/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/business/command/HighlightCommandServiceImplTest.java
@@ -1,20 +1,10 @@
 package com.midas.shootpointer.domain.highlight.business.command;
 
 import com.midas.shootpointer.domain.highlight.business.HighlightManager;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
-import com.midas.shootpointer.domain.member.entity.Member;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class HighlightCommandServiceImplTest {
@@ -23,26 +13,5 @@ class HighlightCommandServiceImplTest {
 
     @Mock
     private HighlightManager highlightManager;
-
-    @DisplayName("manager.selectHighlight(HighlightSelectRequest, Member)가 실행되는지 검증합니다.")
-    @Test
-    void selectHighlight(){
-        //given
-        HighlightSelectRequest request=HighlightSelectRequest.builder()
-                .selectedHighlightIds(List.of(UUID.randomUUID()))
-                .build();
-        Member member=Member.builder()
-                .memberId(UUID.randomUUID())
-                .username("test")
-                .email("test@naver.com")
-                .build();
-
-        //when
-        commandService.selectHighlight(request,member);
-
-        //then
-        verify(highlightManager, times(1)).selectHighlight(request,member);
-    }
-
 
 }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/controller/HighlightControllerTest.java
@@ -3,28 +3,16 @@ package com.midas.shootpointer.domain.highlight.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.midas.shootpointer.WithMockCustomMember;
 import com.midas.shootpointer.domain.highlight.business.HighlightManager;
-import com.midas.shootpointer.domain.highlight.dto.HighlightSelectRequest;
 import com.midas.shootpointer.domain.highlight.dto.HighlightSelectResponse;
-import com.midas.shootpointer.domain.member.entity.Member;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 import java.util.UUID;
-
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 @AutoConfigureMockMvc
 @SpringBootTest
 @ActiveProfiles("test")
@@ -40,53 +28,10 @@ class HighlightCommandControllerTest  {
     private HighlightManager manager;
 
 
-    @Test
-    @DisplayName("하이라이트 영상 선택 POST 요청 성공시 HighlightSelectResponse를 반환합니다._SUCCESS")
-    void selectHighlight() throws Exception {
-        //given
-        String url="/api/highlight/select";
-
-        UUID highlight1=UUID.randomUUID();
-        UUID highlight2=UUID.randomUUID();
-
-        List<UUID> uuids=List.of(highlight1,highlight2);
-        HighlightSelectResponse expectedResponse=mockHighlightSelectResponse(uuids);
-        HighlightSelectRequest request=mockHighlightSelectRequest(uuids);
-
-        when(manager.selectHighlight(any(HighlightSelectRequest.class),any(Member.class)))
-                .thenReturn(expectedResponse);
-
-        //when & then
-        mockMvc.perform(post(url)
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("OK"))
-                .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.selectedHighlightIds",containsInAnyOrder(
-                        highlight1.toString(),
-                        highlight2.toString()
-                )))
-                .andDo(print());
-
-        verify(manager).selectHighlight(any(HighlightSelectRequest.class),any(Member.class));
-    }
-
-
 
 
     private HighlightSelectResponse mockHighlightSelectResponse(List<UUID> uuids){
         return HighlightSelectResponse.builder()
-                .selectedHighlightIds(uuids)
-                .build();
-    }
-
-    /*
-     * Mock HighlightSelectRequest
-     */
-
-    private HighlightSelectRequest mockHighlightSelectRequest(List<UUID> uuids){
-        return HighlightSelectRequest.builder()
                 .selectedHighlightIds(uuids)
                 .build();
     }

--- a/src/test/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntityTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/entity/HighlightEntityTest.java
@@ -1,97 +1,14 @@
 package com.midas.shootpointer.domain.highlight.entity;
 
 import com.midas.shootpointer.domain.member.entity.Member;
-import com.midas.shootpointer.global.common.ErrorCode;
-import com.midas.shootpointer.global.exception.CustomException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 class HighlightEntityTest {
-    @Test
-    @DisplayName("유저의 하이라이트 영상이 아닌 경우 IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID 예외를 반환합니다.")
-    void select_IS_NOT_USERS_HIGHLIGHT(){
-        //given
-        UUID memberId1=UUID.randomUUID();
-        UUID memberId2=UUID.randomUUID();
-
-        Member member1=Member.builder()
-                .email("test@naver.com")
-                .username("test")
-                .memberId(memberId1)
-                .build();
-        Member member2=Member.builder()
-                .email("test2@naver.com")
-                .username("test2")
-                .memberId(memberId2)
-                .build();
-
-        HighlightEntity highlight=HighlightEntity.builder()
-                .member(member1)
-                .highlightKey(UUID.randomUUID())
-                .highlightURL("url")
-                .build();
-
-        //when & then
-        assertThatThrownBy(() -> highlight.select(member2))
-                .isInstanceOf(CustomException.class)
-                .hasMessageContaining(ErrorCode.IS_NOT_CORRECT_MEMBERS_HIGHLIGHT_ID.getMessage());
-    }
-
-    @Test
-    @DisplayName("이미 선택된 하이라이트인 경우 EXISTED_SELECTED 예외를 발생시킵니다.")
-    void select_EXIST_SELECTED(){
-        //given
-        UUID memberId=UUID.randomUUID();
-
-        Member member=Member.builder()
-                .email("test@naver.com")
-                .username("test")
-                .memberId(memberId)
-                .build();
-
-        HighlightEntity highlight=HighlightEntity.builder()
-                .member(member)
-                .highlightKey(UUID.randomUUID())
-                .highlightURL("url")
-                .isSelected(true)
-                .build();
-
-        //when & then
-        assertThatThrownBy(() -> highlight.select(member))
-                .isInstanceOf(CustomException.class)
-                .hasMessageContaining(ErrorCode.EXISTED_SELECTED.getMessage());
-
-    }
-
-    @Test
-    @DisplayName("select 메서드 실행 시 isSelected가 True로 변환됩니다.")
-    void select(){
-        //given
-        UUID memberId=UUID.randomUUID();
-
-        Member member=Member.builder()
-                .email("test@naver.com")
-                .username("test")
-                .memberId(memberId)
-                .build();
-
-        HighlightEntity highlight=HighlightEntity.builder()
-                .member(member)
-                .highlightKey(UUID.randomUUID())
-                .highlightURL("url")
-                .build();
-
-        //when
-        highlight.select(member);
-
-        //then
-        assertThat(highlight.getIsSelected()).isTrue();
-    }
 
     @Test
     @DisplayName("하이라이트 객체의 2점 슛 총합계를 계산합니다.")

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightFactoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -47,9 +48,9 @@ class HighlightFactoryTest {
         BackNumberEntity backNumber=BackNumberEntity.builder()
                 .backNumber(BackNumber.of(10))
                 .build();
-
+        LocalDateTime now=LocalDateTime.now();
         //when
-        List<HighlightEntity> result=factory.createHighlightEntities(highlightInfos,highlightKey,member,backNumber);
+        List<HighlightEntity> result=factory.createHighlightEntities(highlightInfos,highlightKey,member,backNumber,now);
 
         //then
 

--- a/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/mapper/HighlightMapperImplTest.java
@@ -46,7 +46,6 @@ class HighlightMapperImplTest {
                 .highlightURL("url")
                 .highlightKey(highlightKey)
                 .highlightId(highlightId)
-                .isSelected(true)
                 .twoPointCount(20)
                 .threePointCount(30)
                 .build();

--- a/src/test/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepositoryTest.java
+++ b/src/test/java/com/midas/shootpointer/domain/highlight/repository/HighlightQueryRepositoryTest.java
@@ -145,7 +145,6 @@ class HighlightQueryRepositoryTest {
                     .member(member)
                     .threePointCount(random.nextInt(1,100))
                     .twoPointCount(random.nextInt(1,100))
-                    .isSelected(true)
                     .highlightURL("test")
                     .build();
             highlight.setCreatedAt(LocalDateTime.now().minusDays(idx));

--- a/src/test/resources/sql/CreateHighlightDummyData.sql
+++ b/src/test/resources/sql/CreateHighlightDummyData.sql
@@ -117,7 +117,6 @@ $$
                                               member_id,
                                               two_point_count,
                                               three_point_count,
-                                              is_selected,
                                               created_at,
                                               modified_at)
                         VALUES (gen_random_uuid(),
@@ -126,7 +125,6 @@ $$
                                 m.member_id,
                                 FLOOR(random() * 20)::INT, -- 0 ~ 19개
                                 FLOOR(random() * 15)::INT, --0~14개
-                                CASE WHEN random() > 0.15 THEN TRUE ELSE FALSE END,
                                 created_at,
                                 created_at);
                     END LOOP;

--- a/src/test/resources/sql/VerificationHighlightData.sql
+++ b/src/test/resources/sql/VerificationHighlightData.sql
@@ -13,7 +13,6 @@ WITH filtered AS (
         member AS m ON h.member_id = m.member_id
     WHERE
         m.is_aggregation_agreed = TRUE
-      AND h.is_selected = TRUE
       AND h.created_at >= ?
       AND h.created_at <  ?
 )


### PR DESCRIPTION
## 🍀 이슈 번호

- #222 

---

## ✅ 작업 사항

- #223 

---

```java
public record DateTimeRange(LocalDateTime start,LocalDateTime end) {}
```

- 특정 월의 **_시작일~종료일_** 범위를 명확하게 관리하기 위해 레코드 타입으로 정의하였습니다.


```java
@Override
public DateTimeRange getMonthDateTimeRange(int year, int month) {
   LocalDate startDate = LocalDate.of(year, month, 1);
   LocalDate endDate = startDate.withDayOfMonth(startDate.lengthOfMonth());

   LocalDateTime start = startDate.atStartOfDay();
   LocalDateTime end = endDate.atTime(23, 59, 59);
   return new DateTimeRange(start,end);
}
```
- 전달받은 연도/월 기준으로 정확한 월간 범위를 계산합니다.

```java
@Override
public void isValidDateRange(int year, int month) {
    if(year>MAX_YEAR || year<MIN_YEAR) throw new CustomException(ErrorCode.INVALID_YEAR);
    if (month<JANUARY || month>DECEMBER) throw new CustomException(ErrorCode.INVALID_MONTH);
}

```

- 웹계층에서 파라미터로 입력받는 연도와 월의 유효성 검증을 실시합니다.
- 연도의 범위는 `2000~2100` 사이의 값만을 허용합니다.

---

- #224 

```java
public record HighlightCalendarResponse(
        @NotNull Integer year,
        @NotNull Integer month,
        @NotNull List<HighlightCalendarDaysResponse> days
) {}
```

- 최종 반환 DTO를 확인하면 위와 같은 형태입니다.

### DTO 조립 방식

- `JPQL`의` DTO Projection 방식`을 이용하는데 있어 List형태를 쿼리문으로 한 번에 가져오는데 한계가 명확하여 아래와 같은 순서로 DTO를 조립하도록 설계했습니다.

1. `Flat` 데이터 조회
    - `fetchFlatHighlights`를 통해 해당 월의 모든 하이라이트 영상을 조회합니다.
    - 반환 타입: `List<HighlightInfoResponse>`

2. `TreeMap`을 활용한 날짜 기준 그룹핑
   > TreeMap를 사용한 이유?
   일반적인 HashMap 같은 경우 key값의 순서를 보장할 수 없습니다. 따라서, key값인 date를 오름차순으로 반   환하지 못하거나 오름차순으로 반환하려고 한다면 Key를 다시 정렬해야 하는 번거로움을 줄이기 위해 Key 순서를 보장하는 자료구조인 TreeMap를 사용했습니다.
   - **key**: LocalDate
   - **value**: 해당 날짜의 하이라이트 목록
   
3. Mapper를 통한 DTO 변환
   - `TreeMap<LocalDate, List<HighlightInfoResponse>>`→ `List<HighlightCalendarDaysResponse>`로 매핑

4. 최종 DTO 조립
   - `HighlightCalendarResponse` 형태로 최종 반환 객체를 구성합니다.

---

### 변경 사항

1. **HighlightEntity - is_selected 컬럼 삭제**
> 삭제 이유 : 기존 하이라이트가 생성 되었을 때 2개의 하이라이트 영상을 선택하는 플로우에서 전체 하이라이트 영상을 저장하고 게시물을 올리기 전에 선택하는 플로우로 변경.

2. **Highlight API - /api/highlight/select 삭제**
> 삭제 이유 : 상기 플로우 변경에 따라 선택 API 또한 삭제하였습니다.

3. **HighlightQueryRepository - fetchPeriodHighlight GROUP BY 추가**

- #221 에서 작성된 쿼리문에서 COUNT 집계함수를 사용하는데 여기서 이제 GROUP BY를 사용하지 않아 prod 환경에서 API 호출 시 오류발생을 확인하였고 GROUP BY를 통해 해결.

---



---

## ⌨ 기타
