### PR TITLE
🚑Hotfix : SSE 전달 DTO 변경

### DIFF
--- a/src/main/java/com/midas/shootpointer/infrastructure/redis/subscriber/ProgressSubscriber.java
+++ b/src/main/java/com/midas/shootpointer/infrastructure/redis/subscriber/ProgressSubscriber.java
@@ -2,6 +2,7 @@ package com.midas.shootpointer.infrastructure.redis.subscriber;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.midas.shootpointer.domain.progress.dto.ProgressRedisResponse;
+import com.midas.shootpointer.domain.progress.dto.ProgressResponse;
 import com.midas.shootpointer.domain.progress.service.ProgressSseEmitter;
 import com.midas.shootpointer.infrastructure.redis.helper.ProgressValidator;
 import lombok.RequiredArgsConstructor;
@@ -64,11 +65,18 @@ public class ProgressSubscriber implements MessageListener {
             //SUB로 받은 값  null 검증
             validator.validate(progress);
 
+            ProgressResponse response=new ProgressResponse(
+                    progress.status(),
+                    progress.success(),
+                    progress.progress(),
+                    progress.type()
+            );
+
             //SSE로 client에 전달
             emitter.sendToClient(
                     progress.memberId(),
                     jobIdFromChannel, //redis에서 구독한 jobId로 SSE 발행
-                    progress
+                    response
             );
 
             log.info("[Redis SUB] progress info : jobId = {}",progress.jobId());


### PR DESCRIPTION
## ✅ 작업 사항

- 기존 `openCV`에서 받은 Object 객체인 `ProgressRedisResponse`를 `SSE 통신` 응답값으로 직접 전송에서 SSE 전용 응답 객체 `ProgressResponse`를 전송으로 변경.

---

## ⌨ 기타
